### PR TITLE
Increase max_muxing_queue_size to account for 4K files that incorrectly fail validation

### DIFF
--- a/PlexCleaner.sln
+++ b/PlexCleaner.sln
@@ -9,7 +9,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
-		azure-pipelines.yml = azure-pipelines.yml
 		gitversion.yml = gitversion.yml
 		LICENSE = LICENSE
 		PlexCleaner.json = PlexCleaner.json

--- a/PlexCleaner/ConfigFileJsonSchema.cs
+++ b/PlexCleaner/ConfigFileJsonSchema.cs
@@ -14,7 +14,7 @@ namespace PlexCleaner
         public static void WriteDefaultsToFile(string path)
         {
             ConfigFileJsonSchema config = new ConfigFileJsonSchema();
-            ConfigFileJsonSchema.ToFile(path, config);
+            ToFile(path, config);
         }
 
         public static ConfigFileJsonSchema FromFile(string path)

--- a/PlexCleaner/FfMpegTool.cs
+++ b/PlexCleaner/FfMpegTool.cs
@@ -120,16 +120,14 @@ namespace PlexCleaner
             // Create the FFmpeg commandline and execute
             // https://ffmpeg.org/ffmpeg.html
             string snippet = Program.Config.VerifyOptions.VerifyDuration == 0 ? "" : $"-t 0 -ss {Program.Config.VerifyOptions.VerifyDuration}";
-            string commandline = $"-i \"{filename}\" -max_muxing_queue_size 512 -nostats -loglevel error -xerror {snippet} -f null -";
+            string commandline = $"-i \"{filename}\" -max_muxing_queue_size 1024 -nostats -loglevel error -xerror {snippet} -f null -";
             int exitcode = FfMpegCli(commandline, out string _, out error);
 
             // TODO: We sometimes get an invalid argument error, but there is nothing wrong with the commandline
-            // Repeating the exact same operation and it works?
-            // E.g. \\server - 1\media\movies\I, Robot(2004)\I, Robot(2004).mkv: Invalid argument\r\n
             if ((exitcode != 0 || error.Length != 0) &&
                 error.EndsWith(": invalid argument\r\n", StringComparison.OrdinalIgnoreCase))
             {
-                // Try one more time, after waiting a bit, assuming it is a synschronization or file access issue
+                // Try one more time, after waiting a bit, assuming it is a synchronization or file access issue
                 // E.g. observed to happen when system resumes from sleep while processing
                 const int sleepTime = 5;
                 ConsoleEx.WriteLine("");

--- a/PlexCleaner/FfMpegToolJsonSchema.cs
+++ b/PlexCleaner/FfMpegToolJsonSchema.cs
@@ -28,7 +28,7 @@ namespace PlexCleaner.FfMpegToolJsonSchema
     public class Stream
     {
         [JsonProperty("index")]
-        public int Index { get; set; } = 0;
+        public int Index { get; set; }
 
         [JsonProperty("codec_name")]
         public string CodecName { get; set; } = "";
@@ -69,9 +69,9 @@ namespace PlexCleaner.FfMpegToolJsonSchema
     public class Disposition
     {
         [JsonProperty("default")]
-        public bool Default { get; set; } = false;
+        public bool Default { get; set; }
         [JsonProperty("forced")]
-        public bool Forced { get; set; } = false;
+        public bool Forced { get; set; }
     }
 
     public class PacketInfo

--- a/PlexCleaner/KeepAwake.cs
+++ b/PlexCleaner/KeepAwake.cs
@@ -21,7 +21,7 @@ namespace PlexCleaner
         [FlagsAttribute]
         private enum ExecutionState : uint
         {
-            EsAwaymodeRequired = 0x00000040,
+            EsAwayModeRequired = 0x00000040,
             EsContinuous = 0x80000000,
             EsDisplayRequired = 0x00000002,
             EsSystemRequired = 0x00000001

--- a/PlexCleaner/LogFile.cs
+++ b/PlexCleaner/LogFile.cs
@@ -63,8 +63,7 @@ namespace PlexCleaner
             // Match ConsoleEx.WriteLine() formatting
             if (string.IsNullOrEmpty(value))
                 return Environment.NewLine;
-            else
-                return $"{DateTime.Now.ToString(CultureInfo.CurrentCulture)} : {value}" + Environment.NewLine;
+            return $"{DateTime.Now.ToString(CultureInfo.CurrentCulture)} : {value}" + Environment.NewLine;
         }
 
         public string FileName { get; set; }

--- a/PlexCleaner/MediaInfo.cs
+++ b/PlexCleaner/MediaInfo.cs
@@ -103,42 +103,6 @@ namespace PlexCleaner
             return unknown.Count > 0;
         }
 
-        public bool FindNeedReMux(out MediaInfo keep, out MediaInfo remux)
-        {
-            keep = new MediaInfo(Parser);
-            remux = new MediaInfo(Parser);
-
-            // TODO: Add more granular logic to determine a general error vs. a remux correctable error
-
-            // Video
-            foreach (VideoInfo video in Video)
-                if (video.HasErrors)
-                    remux.Video.Add(video);
-                else
-                    keep.Video.Add(video);
-
-            // Audio
-            foreach (AudioInfo audio in Audio)
-                if (audio.HasErrors)
-                    remux.Audio.Add(audio);
-                else
-                    keep.Audio.Add(audio);
-
-            // Subtitle
-            foreach (SubtitleInfo subtitle in Subtitle)
-                if (subtitle.HasErrors)
-                    remux.Subtitle.Add(subtitle);
-                else
-                    keep.Subtitle.Add(subtitle);
-
-            // Set the correct state on all the objects
-            remux.GetTrackList().ForEach(item => item.State = TrackInfo.StateType.ReMux);
-            keep.GetTrackList().ForEach(item => item.State = TrackInfo.StateType.Keep);
-
-            // Return true on any match
-            return remux.Count > 0;
-        }
-
         public bool FindNeedDeInterlace(out MediaInfo keep, out MediaInfo deinterlace)
         {
             keep = new MediaInfo(Parser);
@@ -559,9 +523,12 @@ namespace PlexCleaner
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            foreach (VideoInfo info in Video) sb.AppendLine(info.ToString());
-            foreach (AudioInfo info in Audio) sb.AppendLine(info.ToString());
-            foreach (SubtitleInfo info in Subtitle) sb.AppendLine(info.ToString());
+            foreach (VideoInfo info in Video) 
+                sb.AppendLine(info.ToString());
+            foreach (AudioInfo info in Audio) 
+                sb.AppendLine(info.ToString());
+            foreach (SubtitleInfo info in Subtitle) 
+                sb.AppendLine(info.ToString());
             return sb.ToString();
         }
     }

--- a/PlexCleaner/MkvToolJsonSchema.cs
+++ b/PlexCleaner/MkvToolJsonSchema.cs
@@ -45,22 +45,22 @@ namespace PlexCleaner.MkvToolJsonSchema
     public class ContainerProperties
     {
         [JsonProperty("duration")]
-        public long Duration { get; set; } = 0;
+        public long Duration { get; set; }
     }
 
     public class GlobalTag
     {
         [JsonProperty("num_entries")]
-        public int NumEntries { get; set; } = 0;
+        public int NumEntries { get; set; }
     }
 
     public class TrackTag
     {
         [JsonProperty("num_entries")]
-        public int NumEntries { get; set; } = 0;
+        public int NumEntries { get; set; }
 
         [JsonProperty("track_id")]
-        public int TrackId { get; set; } = 0;
+        public int TrackId { get; set; }
     }
 
     public class Track
@@ -69,7 +69,7 @@ namespace PlexCleaner.MkvToolJsonSchema
         public string Codec { get; set; } = "";
 
         [JsonProperty("id")]
-        public int Id { get; set; } = 0;
+        public int Id { get; set; }
 
         [JsonProperty("properties")]
         public TrackProperties Properties { get; } = new TrackProperties();
@@ -90,18 +90,18 @@ namespace PlexCleaner.MkvToolJsonSchema
         public string Language { get; set; } = "";
 
         [JsonProperty("forced_track")]
-        public bool Forced { get; set; } = false;
+        public bool Forced { get; set; }
 
         [JsonProperty("tag_language")]
         public string TagLanguage { get; set; } = "";
 
         [JsonProperty("number")]
-        public int Number { get; set; } = 0;
+        public int Number { get; set; }
 
         [JsonProperty("track_name")]
         public string TrackName { get; set; } = "";
 
         [JsonProperty("default_track")]
-        public bool DefaultTrack { get; set; } = false;
+        public bool DefaultTrack { get; set; }
     }
 }

--- a/PlexCleaner/Process.cs
+++ b/PlexCleaner/Process.cs
@@ -710,7 +710,7 @@ namespace PlexCleaner
                 return false;
 
             // Nothing more to do for files in the keep extensions list
-            // Except if it is a MKV file or a file to be remuxed
+            // Except if it is a MKV file or a file to be remuxed to MKV
             if (!MkvTool.IsMkvFile(fileinfo) &&
                 !ReMuxExtensions.Contains(fileinfo.Extension) &&
                 KeepExtensions.Contains(fileinfo.Extension))
@@ -720,7 +720,7 @@ namespace PlexCleaner
             if (Program.Cancel.State)
                 return false;
 
-            // ReMux undesirable containers matched by extension
+            // ReMux non-MKV containers matched by extension
             if (!processFile.RemuxByExtensions(ReMuxExtensions, ref modified))
                 return processFile.Result;
 
@@ -732,7 +732,7 @@ namespace PlexCleaner
             if (!processFile.GetMediaInfo())
                 return processFile.Result;
 
-            // ReMux MP4 containers using MKV filenames
+            // ReMux non-MKV containers using MKV filenames
             if (!processFile.RemuxNonMkvContainer(ref modified))
                 return processFile.Result;
 
@@ -768,7 +768,7 @@ namespace PlexCleaner
             // Merge all remux operations into a single call
             // Remove all the unwanted language tracks
             // Remove all duplicate tracks
-            // Remux if any tracks specifically need remuxing
+            // TODO: Remux if any tracks specifically need remuxing
             if (!processFile.ReMux(KeepLanguages, PreferredAudioFormats, ref modified))
                 return processFile.Result;
 
@@ -822,7 +822,7 @@ namespace PlexCleaner
             if (Program.Cancel.State)
                 return false;
 
-            // TODO : Why does the media file timestamp change after processing?
+            // TODO: Why does the media file timestamp change after processing?
             // Speculating there is caching between Windows and Samba and ZFS and timestamps are not synced?
             // https://docs.microsoft.com/en-us/dotnet/api/system.io.filesysteminfo.lastwritetimeutc
             // 10/4/2020 12:03:28 PM : Information : MonitorFileTime : 10/4/2020 7:02:55 PM : "Grand Designs Australia - S07E10 - Daylesford Long House, VIC.mkv"

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -288,20 +288,6 @@ namespace PlexCleaner
                 remux = true;
             }
 
-            // Do any tracks need remuxing
-            // Use MediaInfo logic
-            if (Program.Config.ProcessOptions.ReMux &&
-                MediaInfoInfo.FindNeedReMux(out keep, out remove))
-            {
-                ConsoleEx.WriteLine("");
-                Program.LogFile.LogConsole($"Re-muxing problematic tracks : \"{MediaFile.Name}\"");
-                keep.WriteLine("Keep");
-                remove.WriteLine("ReMux");
-
-                // We can't remux per track, we need to remux entire file
-                remux = true;
-            }
-
             // Any remuxing to do
             if (!remux)
                 // Done

--- a/PlexCleaner/Properties/launchSettings.json
+++ b/PlexCleaner/Properties/launchSettings.json
@@ -10,7 +10,7 @@
     },
     "Process": {
       "commandName": "Project",
-      "commandLineArgs": "--settingsfile \"PlexCleaner.json\" --logfile \"PlexCleaner.log\" --logappend process --mediafiles \"\\\\server-1\\Media\\Series\" \"\\\\server-1\\Media\\Movies\""
+      "commandLineArgs": "--settingsfile \"PlexCleaner.json\" --logfile \"PlexCleaner.log\" --logappend process --mediafiles \"\\\\server-1\\Media\\Series\" \"\\\\server-1\\Media\\Movies\" \"\\\\server-1\\Media\\Movies-4K\""
     },
     "Monitor": {
       "commandName": "Project",
@@ -59,6 +59,10 @@
     "Read Sidecar": {
       "commandName": "Project",
       "commandLineArgs": "--settingsfile \"PlexCleaner.json\" readsidecar --mediafiles \"\\\\server-1\\media\\movies\\The Bourne Identity (2002)\""
+    },
+    "Process Snippets": {
+      "commandName": "Project",
+      "commandLineArgs": "--settingsfile \"PlexCleaner.json\" --logfile \"PlexCleaner.log\" --logappend process --testsnippets --mediafiles \"D:\\Troublesome\""
     }
   }
 }

--- a/PlexCleaner/Tools.cs
+++ b/PlexCleaner/Tools.cs
@@ -219,7 +219,7 @@ namespace PlexCleaner
         private static bool UpdateTool(ToolInfoJsonSchema tools, ToolInfo toolinfo)
         {
             // Get the tool info
-            bool download = false;
+            bool download;
             ToolInfo tool = tools.Tools.FirstOrDefault(t => t.Tool.Equals(toolinfo.Tool, StringComparison.OrdinalIgnoreCase));
             if (tool == null)
             {


### PR DESCRIPTION
Increase max_muxing_queue_size to account for 4K files that incorrectly fail validation.
Fix remux logic when operation fails.
Cleanup Rider warnings.