### PR TITLE
Timestamp enhancement and WMV cover art fix

### DIFF
--- a/PlexCleaner.json
+++ b/PlexCleaner.json
@@ -42,13 +42,13 @@
     // Re-encode the video if the format, codec, and profile values match
     // * will match anything, the number of filter entries must match
     // Use FFProbe attribute naming, and the `printmediainfo` command to get media info
-    "ReEncodeVideoFormats": "mpeg2video,mpeg4,msmpeg4v3,msmpeg4v2,vc1,h264",
-    "ReEncodeVideoCodecs": "*,dx50,div3,mp42,*,*",
-    "ReEncodeVideoProfiles": "*,*,*,*,*,Constrained Baseline@30",
+    "ReEncodeVideoFormats": "mpeg2video,mpeg4,msmpeg4v3,msmpeg4v2,vc1,h264,wmv3",
+    "ReEncodeVideoCodecs": "*,dx50,div3,mp42,*,*,*",
+    "ReEncodeVideoProfiles": "*,*,*,*,*,Constrained Baseline@30,*",
     // Re-encode matching audio codecs
     // If the video format is not H264 or H265, video will automatically be converted to H264 to avoid audio sync issues
     // Use FFProbe attribute naming, and the `printmediainfo` command to get media info
-    "ReEncodeAudioFormats": "flac,mp2,vorbis,wmapro,pcm_s16le,opus",
+    "ReEncodeAudioFormats": "flac,mp2,vorbis,wmapro,pcm_s16le,opus,wmav2",
     // Set default language if tracks have an undefined language
     "SetUnknownLanguage": true,
     // Default track language
@@ -76,6 +76,8 @@
     "SidecarUpdateOnToolChange": false,
     // Enable verify
     "Verify": true,
+    // Restore media file modified timestamp to original value
+    "RestoreFileTimestamp": false,
     // List of media files to ignore, e.g. repeat processing failures, but media still plays
     // Non-ascii characters must be JSON escaped
     "FileIgnoreList": [

--- a/PlexCleaner/MediaInfo.cs
+++ b/PlexCleaner/MediaInfo.cs
@@ -554,28 +554,28 @@ namespace PlexCleaner
             Subtitle.AddRange(addTracks.Subtitle.Where(item => !Subtitle.Contains(item)));
         }
 
-        public static bool GetMediaInfo(FileInfo fileinfo, out MediaInfo ffprobe, out MediaInfo mkvmerge, out MediaInfo mediainfo)
+        public static bool GetMediaInfo(FileInfo fileInfo, out MediaInfo ffprobe, out MediaInfo mkvmerge, out MediaInfo mediainfo)
         {
             ffprobe = null;
             mkvmerge = null;
             mediainfo = null;
 
-            return GetMediaInfo(fileinfo, MediaTool.ToolType.FfProbe, out ffprobe) &&
-                   GetMediaInfo(fileinfo, MediaTool.ToolType.MkvMerge, out mkvmerge) &&
-                   GetMediaInfo(fileinfo, MediaTool.ToolType.MediaInfo, out mediainfo);
+            return GetMediaInfo(fileInfo, MediaTool.ToolType.FfProbe, out ffprobe) &&
+                   GetMediaInfo(fileInfo, MediaTool.ToolType.MkvMerge, out mkvmerge) &&
+                   GetMediaInfo(fileInfo, MediaTool.ToolType.MediaInfo, out mediainfo);
         }
 
-        public static bool GetMediaInfo(FileInfo fileinfo, MediaTool.ToolType parser, out MediaInfo mediainfo)
+        public static bool GetMediaInfo(FileInfo fileInfo, MediaTool.ToolType parser, out MediaInfo mediainfo)
         {
-            if (fileinfo == null)
-                throw new ArgumentNullException(nameof(fileinfo));
+            if (fileInfo == null)
+                throw new ArgumentNullException(nameof(fileInfo));
 
             // Use the specified stream parser tool
             return parser switch
             {
-                MediaTool.ToolType.MediaInfo => Tools.MediaInfo.GetMediaInfo(fileinfo.FullName, out mediainfo),
-                MediaTool.ToolType.MkvMerge => Tools.MkvMerge.GetMkvInfo(fileinfo.FullName, out mediainfo),
-                MediaTool.ToolType.FfProbe => Tools.FfProbe.GetFfProbeInfo(fileinfo.FullName, out mediainfo),
+                MediaTool.ToolType.MediaInfo => Tools.MediaInfo.GetMediaInfo(fileInfo.FullName, out mediainfo),
+                MediaTool.ToolType.MkvMerge => Tools.MkvMerge.GetMkvInfo(fileInfo.FullName, out mediainfo),
+                MediaTool.ToolType.FfProbe => Tools.FfProbe.GetFfProbeInfo(fileInfo.FullName, out mediainfo),
                 _ => throw new NotImplementedException()
             };
         }

--- a/PlexCleaner/MediaInfoTool.cs
+++ b/PlexCleaner/MediaInfoTool.cs
@@ -171,6 +171,10 @@ namespace PlexCleaner
                 {
                     if (track.Type.Equals("Video", StringComparison.OrdinalIgnoreCase))
                     {
+                        // We need to exclude cover art
+                        if (track.CodecId.Equals("V_MJPEG", StringComparison.OrdinalIgnoreCase))
+                            continue;
+
                         VideoInfo info = new(track);
                         mediaInfo.Video.Add(info);
                     }

--- a/PlexCleaner/MkvMergeTool.cs
+++ b/PlexCleaner/MkvMergeTool.cs
@@ -151,6 +151,10 @@ namespace PlexCleaner
                 {
                     if (track.Type.Equals("video", StringComparison.OrdinalIgnoreCase))
                     {
+                        // We need to exclude cover art
+                        if (track.Codec.Equals("V_MJPEG", StringComparison.OrdinalIgnoreCase))
+                            continue;
+
                         VideoInfo info = new(track);
                         mediaInfo.Video.Add(info);
                     }
@@ -212,12 +216,12 @@ namespace PlexCleaner
             return IsMkvExtension(Path.GetExtension(filename));
         }
 
-        public static bool IsMkvFile(FileInfo fileinfo)
+        public static bool IsMkvFile(FileInfo fileInfo)
         {
-            if (fileinfo == null)
-                throw new ArgumentNullException(nameof(fileinfo));
+            if (fileInfo == null)
+                throw new ArgumentNullException(nameof(fileInfo));
 
-            return IsMkvExtension(fileinfo.Extension);
+            return IsMkvExtension(fileInfo.Extension);
         }
 
         public static bool IsMkvExtension(string extension)

--- a/PlexCleaner/Monitor.cs
+++ b/PlexCleaner/Monitor.cs
@@ -175,12 +175,12 @@ namespace PlexCleaner
             if (File.Exists(pathname))
             {
                 // Get the file details
-                FileInfo fileinfo = new(pathname);
+                FileInfo fileInfo = new(pathname);
 
                 // Ignore our own sidecar and *.tmp files being created
-                if (!fileinfo.Extension.Equals(".tmp", StringComparison.OrdinalIgnoreCase) &&
-                    !SidecarFile.IsSidecarFile(fileinfo))
-                    foldername = fileinfo.DirectoryName;
+                if (!fileInfo.Extension.Equals(".tmp", StringComparison.OrdinalIgnoreCase) &&
+                    !SidecarFile.IsSidecarFile(fileInfo))
+                    foldername = fileInfo.DirectoryName;
             }
             // Or directory
             else if(Directory.Exists(pathname))

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -34,7 +34,7 @@ namespace PlexCleaner
                 return true;
 
             // Media file does not exists, delete this sidecar file
-            Log.Logger.Information("Deleting sidecar file with no matching MKV file : {Name}", FileInfo.Name);
+            Log.Logger.Information("Deleting sidecar file with no matching MKV file : {FileName}", FileInfo.Name);
 
             // Delete the file
             if (!Program.Options.TestNoModify &&
@@ -56,12 +56,12 @@ namespace PlexCleaner
             // Only delete if the option is enabled else just skip
             if (!Program.Config.ProcessOptions.DeleteUnwantedExtensions)
             {
-                Log.Logger.Warning("Skipping non-MKV file : {Name}", FileInfo.Name);
+                Log.Logger.Warning("Skipping non-MKV file : {FileName}", FileInfo.Name);
                 return false;
             }
 
             // Non-MKV file, delete
-            Log.Logger.Warning("Deleting non-MKV file : {Name}", FileInfo.Name);
+            Log.Logger.Warning("Deleting non-MKV file : {FileName}", FileInfo.Name);
 
             // Delete the file
             if (!Program.Options.TestNoModify &&
@@ -83,7 +83,7 @@ namespace PlexCleaner
                 return true;
 
             // Make the extension lowercase
-            Log.Logger.Information("Making file extension lowercase : {Name}", FileInfo.Name);
+            Log.Logger.Information("Making file extension lowercase : {FileName}", FileInfo.Name);
 
             // Rename the file
             // Windows is case insensitive, so we need to rename in two steps
@@ -126,7 +126,7 @@ namespace PlexCleaner
                 return true;
 
             // ReMux the file
-            Log.Logger.Information("ReMux file matched by extension : {Name}", FileInfo.Name);
+            Log.Logger.Information("ReMux file matched by extension : {FileName}", FileInfo.Name);
 
             // Remux the file, use the new filename
             // Convert will test for Options.TestNoModify
@@ -159,7 +159,7 @@ namespace PlexCleaner
                 return true;
 
             // ReMux the file
-            Log.Logger.Information("ReMux {Container} container : {Name}", MkvMergeInfo.Container, FileInfo.Name);
+            Log.Logger.Information("ReMux {Container} container : {FileName}", MkvMergeInfo.Container, FileInfo.Name);
 
             // Remux the file, use the new filename
             // Convert will test for Options.TestNoModify
@@ -191,13 +191,13 @@ namespace PlexCleaner
             // Look for the ReMuxed flag and don't try to remux again
             if (SidecarFile.State.HasFlag(SidecarFile.States.ReMuxed))
             {
-                Log.Logger.Warning("Skipping ReMux due to previous ReMux failed to clear errors : {Name}", FileInfo.Name);
+                Log.Logger.Warning("Skipping ReMux due to previous ReMux failed to clear errors : {FileName}", FileInfo.Name);
                 // Return success
                 return true;
             }
 
             // Try to ReMux the file
-            Log.Logger.Information("ReMux to repair metadata errors : {Name}", FileInfo.Name);
+            Log.Logger.Information("ReMux to repair metadata errors : {FileName}", FileInfo.Name);
 
             // Remux the file, use the new filename
             if (!Convert.ReMuxToMkv(FileInfo.FullName, out string outputname))
@@ -220,9 +220,9 @@ namespace PlexCleaner
                 MkvMergeInfo.HasErrors ||
                 MediaInfoInfo.HasErrors)
                 // Ignore error
-                Log.Logger.Warning("ReMux failed to clear metadata errors : {Name}", FileInfo.Name);
+                Log.Logger.Warning("ReMux failed to clear metadata errors : {FileName}", FileInfo.Name);
             else
-                Log.Logger.Information("ReMux cleared metadata errors : {Name}", FileInfo.Name);
+                Log.Logger.Information("ReMux cleared metadata errors : {FileName}", FileInfo.Name);
 
             // Extension may have changed
             return result;
@@ -240,7 +240,7 @@ namespace PlexCleaner
                 return true;
 
             // Remove tags
-            Log.Logger.Information("Clearing all tags from media file : {Name}", FileInfo.Name);
+            Log.Logger.Information("Clearing all tags from media file : {FileName}", FileInfo.Name);
 
             // Delete the tags
             if (!Program.Options.TestNoModify &&
@@ -267,7 +267,7 @@ namespace PlexCleaner
                 // Nothing to do
                 return true;
 
-            Log.Logger.Information("Setting unknown language tracks to {DefaultLanguage} : {Name}", 
+            Log.Logger.Information("Setting unknown language tracks to {DefaultLanguage} : {FileName}", 
                                    Program.Config.ProcessOptions.DefaultLanguage, 
                                    FileInfo.Name);
             known.WriteLine("Known");
@@ -299,7 +299,7 @@ namespace PlexCleaner
             if (Program.Config.ProcessOptions.RemoveUnwantedLanguageTracks &&
                 MkvMergeInfo.FindUnwantedLanguage(keepLanguages, preferredAudioFormats, out MediaInfo keep, out MediaInfo remove))
             {
-                Log.Logger.Information("Removing unwanted language tracks : {Name}", FileInfo.Name);
+                Log.Logger.Information("Removing unwanted language tracks : {FileName}", FileInfo.Name);
                 keep.WriteLine("Keep");
                 remove.WriteLine("Remove");
 
@@ -314,7 +314,7 @@ namespace PlexCleaner
             if (Program.Config.ProcessOptions.RemoveDuplicateTracks &&
                 MkvMergeInfo.FindDuplicateTracks(preferredAudioFormats, out keep, out remove))
             {
-                Log.Logger.Information("Removing duplicate tracks : {Name}", FileInfo.Name);
+                Log.Logger.Information("Removing duplicate tracks : {FileName}", FileInfo.Name);
                 keep.WriteLine("Keep");
                 remove.WriteLine("Remove");
 
@@ -329,7 +329,7 @@ namespace PlexCleaner
                 // Done
                 return true;
 
-            Log.Logger.Information("Re-muxing union of tracks : {Name}", FileInfo.Name);
+            Log.Logger.Information("Re-muxing union of tracks : {FileName}", FileInfo.Name);
             keepTracks.WriteLine("Keep");
             removeTracks.WriteLine("Remove");
 
@@ -358,7 +358,7 @@ namespace PlexCleaner
             if (!FfProbeInfo.FindNeedDeInterlace(out MediaInfo keepTracks, out MediaInfo deinterlaceTracks))
                 return true;
 
-            Log.Logger.Information("De-interlacing interlaced video : {Name}", FileInfo.Name);
+            Log.Logger.Information("De-interlacing interlaced video : {FileName}", FileInfo.Name);
             keepTracks.WriteLine("Keep");
             deinterlaceTracks.WriteLine("DeInterlace");
 
@@ -394,7 +394,7 @@ namespace PlexCleaner
                 // Done
                 return true;
 
-            Log.Logger.Information("Re-muxing tracks : {Name}", FileInfo.Name);
+            Log.Logger.Information("Re-muxing tracks : {FileName}", FileInfo.Name);
             keepTracks.WriteLine("Keep");
             removeTracks.WriteLine("Remove");
 
@@ -425,7 +425,7 @@ namespace PlexCleaner
                 // Nothing to do
                 return true;
 
-            Log.Logger.Information("Re-encoding required tracks : {Name}", FileInfo.Name);
+            Log.Logger.Information("Re-encoding required tracks : {FileName}", FileInfo.Name);
             keep.WriteLine("Passthrough");
             reencode.WriteLine("ReEncode");
 
@@ -464,7 +464,7 @@ namespace PlexCleaner
                 if (Program.Config.VerifyOptions.MinimumFileAge > 0 &&
                     fileAge > testAge)
                 {
-                    Log.Logger.Warning("Skipping file due to age : {FileAge} > {TestAge} : {Name}", fileAge, testAge, FileInfo.Name);
+                    Log.Logger.Warning("Skipping file due to age : {FileAge} > {TestAge} : {FileName}", fileAge, testAge, FileInfo.Name);
                     return true;
                 }
             }
@@ -477,7 +477,7 @@ namespace PlexCleaner
                 if (MediaInfoInfo.Video.Count == 0 || MediaInfoInfo.Audio.Count == 0)
                 {
                     // File is missing required streams
-                    Log.Logger.Error("File missing required tracks : {Name}", FileInfo.Name);
+                    Log.Logger.Error("File missing required tracks : {FileName}", FileInfo.Name);
                     MediaInfoInfo.WriteLine("Invalid");
                     
                     // Done
@@ -488,7 +488,7 @@ namespace PlexCleaner
                 if (MkvMergeInfo.Duration < TimeSpan.FromMinutes(Program.Config.VerifyOptions.MinimumDuration))
                 {
                     // Playback duration is too short
-                    Log.Logger.Error("File play duration is too short : {Duration} < {MinimumDuration} : {Name}",
+                    Log.Logger.Error("File play duration is too short : {Duration} < {MinimumDuration} : {FileName}",
                                      MkvMergeInfo.Duration,
                                      TimeSpan.FromMinutes(Program.Config.VerifyOptions.MinimumDuration),
                                      FileInfo.Name);
@@ -499,7 +499,7 @@ namespace PlexCleaner
                 }
 
                 // Verify media streams
-                Log.Logger.Information("Verifying media streams : {Name}", FileInfo.Name);
+                Log.Logger.Information("Verifying media streams : {FileName}", FileInfo.Name);
                 if (!Tools.FfMpeg.VerifyMedia(FileInfo.FullName, out string error))
                 {
                     // Cancel requested
@@ -507,7 +507,7 @@ namespace PlexCleaner
                         return false;
 
                     // Failed stream validation
-                    Log.Logger.Error("Media stream validation failed : {Name}", FileInfo.Name);
+                    Log.Logger.Error("Media stream validation failed : {FileName}", FileInfo.Name);
                     Log.Logger.Error("{Error}", error);
 
                     // Should we attempt file repair
@@ -581,7 +581,7 @@ namespace PlexCleaner
                 { 
                     // Delete the media file and sidecar file
                     // Ignore delete errors
-                    Log.Logger.Information("Deleting media file due to failed verification : {Name}", FileInfo.FullName);
+                    Log.Logger.Information("Deleting media file due to failed verification : {FileName}", FileInfo.FullName);
                     FileEx.DeleteFile(FileInfo.FullName);
                     FileEx.DeleteFile(SidecarFile.GetSidecarName(FileInfo));
 
@@ -619,10 +619,10 @@ namespace PlexCleaner
             // https://en.wikipedia.org/wiki/YIFY
 
             // Calculate bitrate
-            Log.Logger.Information("Calculating bitrate info : {Name}", FileInfo.Name);
+            Log.Logger.Information("Calculating bitrate info : {FileName}", FileInfo.Name);
             if (!GetBitrateInfo(out BitrateInfo bitrateInfo))
             {
-                Log.Logger.Error("Failed to calculate bitrate info : {Name}", FileInfo.Name);
+                Log.Logger.Error("Failed to calculate bitrate info : {FileName}", FileInfo.Name);
                 return false;
             }
 
@@ -632,7 +632,7 @@ namespace PlexCleaner
             // Combined bitrate exceeded threshold
             if (bitrateInfo.CombinedBitrate.Exceeded > 0)
             {
-                Log.Logger.Warning("Maximum bitrate exceeded : {CombinedBitrate} > {MaximumBitrate} : {Name}",
+                Log.Logger.Warning("Maximum bitrate exceeded : {CombinedBitrate} > {MaximumBitrate} : {FileName}",
                                     Bitrate.ToBitsPerSecond(bitrateInfo.CombinedBitrate.Maximum),
                                     Bitrate.ToBitsPerSecond(Program.Config.VerifyOptions.MaximumBitrate / 8),
                                     FileInfo.Name);
@@ -644,7 +644,7 @@ namespace PlexCleaner
 
             // Audio bitrate exceeds video bitrate, may indicate an error with the video track
             if (bitrateInfo.AudioBitrate.Average > bitrateInfo.VideoBitrate.Average)
-                Log.Logger.Warning("Audio bitrate exceeds Video bitrate : {AudioBitrate} > {VideoBitrate} : {Name}",
+                Log.Logger.Warning("Audio bitrate exceeds Video bitrate : {AudioBitrate} > {VideoBitrate} : {FileName}",
                                     Bitrate.ToBitsPerSecond(bitrateInfo.AudioBitrate.Average),
                                     Bitrate.ToBitsPerSecond(bitrateInfo.VideoBitrate.Average),
                                     FileInfo.Name);
@@ -716,7 +716,7 @@ namespace PlexCleaner
             }
             if (!hdr10)
             {
-                Log.Logger.Warning("Video lacks HDR10 compatibility : {Hdr} : {Name}", videoInfo.FormatHdr, FileInfo.Name);
+                Log.Logger.Warning("Video lacks HDR10 compatibility : {Hdr} : {FileName}", videoInfo.FormatHdr, FileInfo.Name);
             }
 
             // Ignore the error
@@ -734,20 +734,20 @@ namespace PlexCleaner
                 return true;
 
             // Disagreement in interlaced flags
-            Log.Logger.Warning("Interlaced flags do not match : {MediainfoInterlaced} != {FfprobeInterlaced} : {Name}",
+            Log.Logger.Warning("Interlaced flags do not match : {MediainfoInterlaced} != {FfprobeInterlaced} : {FileName}",
                                 mediainfoInterlaced,
                                 ffprobeInterlaced,
                                 FileInfo.Name);
-            Log.Logger.Information("Calculating interlaced frame info : {Name}", FileInfo.Name);
+            Log.Logger.Information("Calculating interlaced frame info : {FileName}", FileInfo.Name);
             if (!Tools.FfMpeg.GetIdetInfo(FileInfo.FullName, out FfMpegIdetInfo idetinfo))
             { 
-                Log.Logger.Error("Failed to calculate interlaced frame info : {Name}", FileInfo.Name);
+                Log.Logger.Error("Failed to calculate interlaced frame info : {FileName}", FileInfo.Name);
                 return false;
             }
 
             // Idet
             bool idetinterlaced = idetinfo.IsInterlaced(out double single, out double multi);
-            Log.Logger.Information("FfMpeg interlace detection : Single: {Single:P}, Multi: {Multi:P}, Interlaced: {IdetInterlaced} : {Name}",
+            Log.Logger.Information("FfMpeg interlace detection : Single: {Single:P}, Multi: {Multi:P}, Interlaced: {IdetInterlaced} : {FileName}",
                                     single,
                                     multi,
                                     idetinterlaced,
@@ -767,7 +767,7 @@ namespace PlexCleaner
             if (SidecarFile.State.HasFlag(SidecarFile.States.RepairFailed))
             {
                 // Just warn, maybe tools changed, try again
-                Log.Logger.Warning("Previous attempts to repair failed : {State} : {Name}", SidecarFile.State, FileInfo.Name);
+                Log.Logger.Warning("Previous attempts to repair failed : {State} : {FileName}", SidecarFile.State, FileInfo.Name);
             }
 
             // TODO : Analyze the error output and conditionally repair only the audio or video track
@@ -808,7 +808,7 @@ namespace PlexCleaner
             string tempname = Path.ChangeExtension(FileInfo.FullName, ".tmp");
 
             // Convert using ffmpeg
-            Log.Logger.Information("Attempting media repair by re-encoding using FfMpeg : {Name}", FileInfo.Name);
+            Log.Logger.Information("Attempting media repair by re-encoding using FfMpeg : {FileName}", FileInfo.Name);
             if (!Tools.FfMpeg.ConvertToMkv(FileInfo.FullName, tempname))
             {
                 // Failed, delete temp file
@@ -819,7 +819,7 @@ namespace PlexCleaner
                     return false;
 
                 // Try again using handbrake
-                Log.Logger.Information("Attempting media repair by re-encoding using HandBrake : {Name}", FileInfo.Name);
+                Log.Logger.Information("Attempting media repair by re-encoding using HandBrake : {FileName}", FileInfo.Name);
                 if (!Tools.HandBrake.ConvertToMkv(FileInfo.FullName, tempname))
                 {
                     // Failed, delete temp file
@@ -830,7 +830,7 @@ namespace PlexCleaner
                         return false;
 
                     // Failed again
-                    Log.Logger.Error("Repair by re-encoding failed : {Name}", FileInfo.Name);
+                    Log.Logger.Error("Repair by re-encoding failed : {FileName}", FileInfo.Name);
 
                     // Update state
                     // Caller will Refresh()
@@ -841,7 +841,7 @@ namespace PlexCleaner
             }
 
             // Re-encoding succeeded, re-verify the temp file
-            Log.Logger.Information("Re-verifying media streams : {Name}", FileInfo.Name);
+            Log.Logger.Information("Re-verifying media streams : {FileName}", FileInfo.Name);
             if (!Tools.FfMpeg.VerifyMedia(tempname, out string error))
             {
                 // Failed, delete temp file
@@ -852,7 +852,7 @@ namespace PlexCleaner
                     return false;
 
                 // Failed stream validation
-                Log.Logger.Error("Media stream validation failed after repair attempt : {Name}", FileInfo.Name);
+                Log.Logger.Error("Media stream validation failed after repair attempt : {FileName}", FileInfo.Name);
                 Log.Logger.Error("{Error}", error);
 
                 // Update state
@@ -867,7 +867,7 @@ namespace PlexCleaner
                 return false;
 
             // Repair succeeded
-            Log.Logger.Information("Repair succeeded : {Name}", FileInfo.Name);
+            Log.Logger.Information("Repair succeeded : {FileName}", FileInfo.Name);
 
             // Update state
             SidecarFile.State |= SidecarFile.States.Repaired;
@@ -944,6 +944,22 @@ namespace PlexCleaner
             return true;
         }
 
+        public bool VerifyMediaInfo()
+        { 
+            // Make sure that the track counts match, else something went wrong
+            if (FfProbeInfo.Audio.Count != MkvMergeInfo.Audio.Count ||
+                MkvMergeInfo.Audio.Count != MediaInfoInfo.Audio.Count ||
+                FfProbeInfo.Video.Count != MkvMergeInfo.Video.Count ||
+                MkvMergeInfo.Video.Count != MediaInfoInfo.Video.Count ||
+                FfProbeInfo.Subtitle.Count != MkvMergeInfo.Subtitle.Count ||
+                MkvMergeInfo.Subtitle.Count != MediaInfoInfo.Subtitle.Count)
+            {
+                Log.Logger.Error("Tool track count discrepency : {File}", FileInfo.Name);
+                return false;
+            }
+            return true;
+        }
+
         public bool GetMediaInfo()
         {
             // Only MKV files
@@ -961,7 +977,7 @@ namespace PlexCleaner
                 !Tools.MkvMerge.GetMkvInfoJson(FileInfo.FullName, out mkvMergeInfoJson) ||
                 !Tools.FfProbe.GetFfProbeInfoJson(FileInfo.FullName, out ffProbeInfoJson))
             {
-                Log.Logger.Error("Failed to read tool info : {Name}", FileInfo.Name);
+                Log.Logger.Error("Failed to read tool info : {FileName}", FileInfo.Name);
                 return false;
             }
 
@@ -978,7 +994,7 @@ namespace PlexCleaner
             bool timestampChanged = false;
             FileInfo.Refresh();
             DateTime fileTime = FileInfo.LastWriteTimeUtc;
-            Log.Logger.Information("MonitorFileTime : {FileTime} : {Name}\"", fileTime, FileInfo.Name);
+            Log.Logger.Information("MonitorFileTime : {FileTime} : {FileName}\"", fileTime, FileInfo.Name);
             for (int i = 0; i < seconds; i ++)
             {
                 if (Program.IsCancelled(1000))
@@ -987,7 +1003,7 @@ namespace PlexCleaner
                 if (FileInfo.LastWriteTimeUtc != fileTime)
                 {
                     timestampChanged = true;
-                    Log.Logger.Warning("MonitorFileTime : {LastWriteTimeUtc} != {FileTime} : {Name}", 
+                    Log.Logger.Warning("MonitorFileTime : {LastWriteTimeUtc} != {FileTime} : {FileName}", 
                                        FileInfo.LastWriteTimeUtc, 
                                        fileTime, 
                                        FileInfo.Name);

--- a/PlexCleaner/ProcessOptions.cs
+++ b/PlexCleaner/ProcessOptions.cs
@@ -11,10 +11,10 @@ namespace PlexCleaner
         public string ReMuxExtensions { get; set; } = ".avi,.m2ts,.ts,.vob,.mp4,.m4v,.asf,.wmv";
         public bool DeInterlace { get; set; } = true;
         public bool ReEncode { get; set; } = true;
-        public string ReEncodeVideoFormats { get; set; } = "mpeg2video,mpeg4,msmpeg4v3,msmpeg4v2,vc1,h264";
-        public string ReEncodeVideoCodecs { get; set; } = "*,dx50,div3,mp42,*,*";
-        public string ReEncodeVideoProfiles { get; set; } = "*,*,*,*,*,Constrained Baseline@30";
-        public string ReEncodeAudioFormats { get; set; } = "flac,mp2,vorbis,wmapro,pcm_s16le,opus";
+        public string ReEncodeVideoFormats { get; set; } = "mpeg2video,mpeg4,msmpeg4v3,msmpeg4v2,vc1,h264,wmv3";
+        public string ReEncodeVideoCodecs { get; set; } = "*,dx50,div3,mp42,*,*,*";
+        public string ReEncodeVideoProfiles { get; set; } = "*,*,*,*,*,Constrained Baseline@30,*";
+        public string ReEncodeAudioFormats { get; set; } = "flac,mp2,vorbis,wmapro,pcm_s16le,opus,wmav2";
         public bool SetUnknownLanguage { get; set; } = true;
         public string DefaultLanguage { get; set; } = "eng";
         public bool RemoveUnwantedLanguageTracks { get; set; } = true;
@@ -25,6 +25,7 @@ namespace PlexCleaner
         public bool UseSidecarFiles { get; set; } = true;
         public bool SidecarUpdateOnToolChange { get; set; }
         public bool Verify { get; set; } = true;
+        public bool RestoreFileTimestamp { get; set; } = false;
         public List<string> FileIgnoreList { get; } = new();
     }
 }

--- a/PlexCleaner/Program.cs
+++ b/PlexCleaner/Program.cs
@@ -304,7 +304,7 @@ namespace PlexCleaner
             // Compare the schema version
             if (config.SchemaVersion != ConfigFileJsonSchema.CurrentSchemaVersion)
             {
-                Log.Logger.Warning("Settings JSON schema mismatch : {JsonSchemaVersion} != {CurrentSchemaVersion}, {Name}",
+                Log.Logger.Warning("Settings JSON schema mismatch : {JsonSchemaVersion} != {CurrentSchemaVersion}, {FileName}",
                                    config.SchemaVersion,
                                    ConfigFileJsonSchema.CurrentSchemaVersion,
                                    options.SettingsFile);
@@ -399,10 +399,10 @@ namespace PlexCleaner
                     FolderList.Add(fileorfolder);
 
                     // Create the file list from the directory
-                    Log.Logger.Information("Getting files and folders from {Name} ...", dirInfo.FullName);
+                    Log.Logger.Information("Getting files and folders from {Directory} ...", dirInfo.FullName);
                     if (!FileEx.EnumerateDirectory(fileorfolder, out List<FileInfo> fileInfoList, out List<DirectoryInfo> directoryInfoList))
                     {
-                        Log.Logger.Error("Failed to enumerate directory {Name}", fileorfolder);
+                        Log.Logger.Error("Failed to enumerate directory {Directory}", fileorfolder);
                         return false;
                     }
                     FileInfoList.AddRange(fileInfoList);

--- a/PlexCleaner/Properties/launchSettings.json
+++ b/PlexCleaner/Properties/launchSettings.json
@@ -10,7 +10,7 @@
     },
     "Process": {
       "commandName": "Project",
-      "commandLineArgs": "--settingsfile \"PlexCleaner.json\" --logfile \"PlexCleaner.log\" --logappend process --mediafiles \"\\\\server-1\\Media\\Series\" \"\\\\server-1\\Media\\Movies\" \"\\\\server-1\\Media\\Movies-4K\""
+      "commandLineArgs": "--settingsfile \"PlexCleaner.json\" --logfile \"PlexCleaner.log\" --logappend process --mediafiles \"\\\\server-1\\Media\\Series\" --mediafiles \"\\\\server-1\\Media\\Movies\" --mediafiles \"\\\\server-1\\Media\\Movies-4K\""
     },
     "Monitor": {
       "commandName": "Project",
@@ -50,7 +50,7 @@
     },
     "Test": {
       "commandName": "Project",
-      "commandLineArgs": "--settingsfile \"PlexCleaner.json\" --logfile \"PlexCleaner.log\" process --mediafiles \"\\\\Server-1\\Media\\Movies-4K\""
+      "commandLineArgs": "--settingsfile \"PlexCleaner.json\" --logfile \"PlexCleaner.log\" process --mediafiles \"D:\\Test\""
     },
     "Docker": {
       "commandName": "Docker"

--- a/PlexCleaner/SidecarFile.cs
+++ b/PlexCleaner/SidecarFile.cs
@@ -51,7 +51,7 @@ namespace PlexCleaner
             if (!WriteJson())
                 return false;
 
-            Log.Logger.Information("Sidecar created : State: {States} : {Name}", State, SidecarFileInfo.Name);
+            Log.Logger.Information("Sidecar created : State: {States} : {FileName}", State, SidecarFileInfo.Name);
 
             return true;
         }
@@ -73,12 +73,12 @@ namespace PlexCleaner
                 // Remove the verified state flag
                 if (State.HasFlag(States.Verified))
                 { 
-                    Log.Logger.Warning("Sidecar out of sync, clearing Verified flag : {Name}", SidecarFileInfo.Name);
+                    Log.Logger.Warning("Sidecar out of sync, clearing Verified flag : {FileName}", SidecarFileInfo.Name);
                     State &= ~States.Verified;
                 }
             }
 
-            Log.Logger.Information("Sidecar read : State: {States} : {Name}", State, SidecarFileInfo.Name);
+            Log.Logger.Information("Sidecar read : State: {States} : {FileName}", State, SidecarFileInfo.Name);
 
             return true;
         }
@@ -112,7 +112,7 @@ namespace PlexCleaner
             if (!WriteJson())
                 return false;
 
-            Log.Logger.Information("Sidecar updated : State: {States} : {Name}", State, SidecarFileInfo.Name);
+            Log.Logger.Information("Sidecar updated : State: {States} : {FileName}", State, SidecarFileInfo.Name);
 
             return true;
         }
@@ -136,7 +136,7 @@ namespace PlexCleaner
             MkvMergeInfo = null;
             MediaInfoInfo = null;
 
-            Log.Logger.Information("Sidecar deleted : {Name}", SidecarFileInfo.Name);
+            Log.Logger.Information("Sidecar deleted : {FileName}", SidecarFileInfo.Name);
 
             return true;
         }
@@ -197,7 +197,7 @@ namespace PlexCleaner
                 update = true;
             if (!update)
             { 
-                Log.Logger.Information("Sidecar up to date : State: {States} : {Name}", State, SidecarFileInfo.Name);
+                Log.Logger.Information("Sidecar up to date : State: {States} : {FileName}", State, SidecarFileInfo.Name);
                 return true;
             }
 
@@ -207,7 +207,7 @@ namespace PlexCleaner
                 !WriteJson())
                 return false;
 
-            Log.Logger.Information("Sidecar upgraded : State: {States} : {Name}", State, SidecarFileInfo.Name);
+            Log.Logger.Information("Sidecar upgraded : State: {States} : {FileName}", State, SidecarFileInfo.Name);
 
             return true;
         }
@@ -258,7 +258,7 @@ namespace PlexCleaner
 
         private bool GetInfoFromJson()
         {
-            Log.Logger.Information("Reading media info from sidecar : {Name}", SidecarFileInfo.Name);
+            Log.Logger.Information("Reading media info from sidecar : {FileName}", SidecarFileInfo.Name);
 
             // Decompress the tool data
             FfProbeInfoJson = StringCompression.Decompress(SidecarJson.FfProbeInfoData);
@@ -273,7 +273,7 @@ namespace PlexCleaner
                 !Tools.MkvMerge.GetMkvInfoFromJson(MkvMergeInfoJson, out mkvMergeInfo) ||
                 !Tools.FfProbe.GetFfProbeInfoFromJson(FfProbeInfoJson, out ffProbeInfo))
             {
-                Log.Logger.Error("Failed to de-serialize tool data : {Name}", SidecarFileInfo.Name);
+                Log.Logger.Error("Failed to de-serialize tool data : {FileName}", SidecarFileInfo.Name);
                 return false;
             }
 
@@ -300,7 +300,7 @@ namespace PlexCleaner
                 // Ignore LastWriteTimeUtc, it is unreliable over SMB
                 // mismatch = true;
                 if (log)
-                    Log.Logger.Warning("Sidecar LastWriteTimeUtc out of sync with media file : {SidecarJsonMediaLastWriteTimeUtc} != {MediaFileLastWriteTimeUtc} : {Name}",
+                    Log.Logger.Warning("Sidecar LastWriteTimeUtc out of sync with media file : {SidecarJsonMediaLastWriteTimeUtc} != {MediaFileLastWriteTimeUtc} : {FileName}",
                                        SidecarJson.MediaLastWriteTimeUtc,
                                        MediaFileInfo.LastWriteTimeUtc,
                                        SidecarFileInfo.Name);
@@ -309,7 +309,7 @@ namespace PlexCleaner
             {
                 mismatch = true;
                 if (log)
-                    Log.Logger.Warning("Sidecar FileLength out of sync with media file : {SidecarJsonMediaLength} != {MediaFileLength} : {Name}",
+                    Log.Logger.Warning("Sidecar FileLength out of sync with media file : {SidecarJsonMediaLength} != {MediaFileLength} : {FileName}",
                                        SidecarJson.MediaLength,
                                        MediaFileInfo.Length,
                                        SidecarFileInfo.Name);
@@ -319,7 +319,7 @@ namespace PlexCleaner
             {
                 mismatch = true;
                 if (log)
-                    Log.Logger.Warning("Sidecar SHA256 out of sync with media file : {SidecarJsonHash} != {MediaFileHash} : {Name}",
+                    Log.Logger.Warning("Sidecar SHA256 out of sync with media file : {SidecarJsonHash} != {MediaFileHash} : {FileName}",
                                        SidecarJson.MediaHash,
                                        hash,
                                        SidecarFileInfo.Name);
@@ -336,7 +336,7 @@ namespace PlexCleaner
             {
                 mismatch = true;
                 if (log)
-                    Log.Logger.Warning("Sidecar FfProbe tool version out of date : {SidecarJsonFfProbeToolVersion} != {ToolsFfProbeInfoVersion} : {Name}",
+                    Log.Logger.Warning("Sidecar FfProbe tool version out of date : {SidecarJsonFfProbeToolVersion} != {ToolsFfProbeInfoVersion} : {FileName}",
                                        SidecarJson.FfProbeToolVersion,
                                        Tools.FfProbe.Info.Version,
                                        SidecarFileInfo.Name);
@@ -345,7 +345,7 @@ namespace PlexCleaner
             {
                 mismatch = true;
                 if (log)
-                    Log.Logger.Warning("Sidecar MkvMerge tool version out of date : {SidecarJsonMkvMergeToolVersion} != {ToolsMkvMergeInfoVersion} : {Name}",
+                    Log.Logger.Warning("Sidecar MkvMerge tool version out of date : {SidecarJsonMkvMergeToolVersion} != {ToolsMkvMergeInfoVersion} : {FileName}",
                                        SidecarJson.MkvMergeToolVersion,
                                        Tools.MkvMerge.Info.Version,
                                        SidecarFileInfo.Name);
@@ -354,7 +354,7 @@ namespace PlexCleaner
             {
                 mismatch = true;
                 if (log)
-                    Log.Logger.Warning("Sidecar MediaInfo tool version out of date : {SidecarJsonMediaInfoToolVersion} != {ToolsMediaInfoVersion} : {Name}",
+                    Log.Logger.Warning("Sidecar MediaInfo tool version out of date : {SidecarJsonMediaInfoToolVersion} != {ToolsMediaInfoVersion} : {FileName}",
                                        SidecarJson.MediaInfoToolVersion,
                                        Tools.MediaInfo.Info.Version,
                                        SidecarFileInfo.Name);
@@ -383,7 +383,7 @@ namespace PlexCleaner
             // Compare the schema version
             if (SidecarJson.SchemaVersion != SidecarFileJsonSchema.CurrentSchemaVersion)
             {
-                Log.Logger.Warning("Sidecar JSON schema mismatch : {JsonSchemaVersion} != {CurrentSchemaVersion}, {Name}",
+                Log.Logger.Warning("Sidecar JSON schema mismatch : {JsonSchemaVersion} != {CurrentSchemaVersion}, {FileName}",
                                    SidecarJson.SchemaVersion,
                                    SidecarFileJsonSchema.CurrentSchemaVersion,
                                    SidecarFileInfo.Name);
@@ -448,14 +448,14 @@ namespace PlexCleaner
 
         private bool GetToolInfo()
         {
-            Log.Logger.Information("Reading media info from tools : {Name}", MediaFileInfo.Name);
+            Log.Logger.Information("Reading media info from tools : {FileName}", MediaFileInfo.Name);
 
             // Read the tool data text
             if (!Tools.MediaInfo.GetMediaInfoXml(MediaFileInfo.FullName, out MediaInfoXml) ||
                 !Tools.MkvMerge.GetMkvInfoJson(MediaFileInfo.FullName, out MkvMergeInfoJson) ||
                 !Tools.FfProbe.GetFfProbeInfoJson(MediaFileInfo.FullName, out FfProbeInfoJson))
             {
-                Log.Logger.Error("Failed to read media info : {Name}", MediaFileInfo.Name);
+                Log.Logger.Error("Failed to read media info : {FileName}", MediaFileInfo.Name);
                 return false;
             }
 
@@ -467,7 +467,7 @@ namespace PlexCleaner
                 !Tools.MkvMerge.GetMkvInfoFromJson(MkvMergeInfoJson, out mkvMergeInfo) ||
                 !Tools.FfProbe.GetFfProbeInfoFromJson(FfProbeInfoJson, out ffProbeInfo))
             {
-                Log.Logger.Error("Failed to de-serialize tool data : {Name}", MediaFileInfo.Name);
+                Log.Logger.Error("Failed to de-serialize tool data : {FileName}", MediaFileInfo.Name);
                 return false;
             }
 
@@ -484,10 +484,16 @@ namespace PlexCleaner
             return true;
         }
 
+        public static bool CanHash(FileInfo fileInfo)
+        {
+            // Media file must be at least 2 * the hash window length
+            return fileInfo.Length >= 2 * HashWindowLength;
+        }
+
         private string ComputeHash()
         {
             // Media file must be at least 2 * the hash window length
-            Debug.Assert(MediaFileInfo.Length >= 2 * HashWindowLength);
+            Debug.Assert(CanHash(MediaFileInfo));
 
             try
             {
@@ -504,7 +510,7 @@ namespace PlexCleaner
                 fileStream.Seek(0, SeekOrigin.Begin);
                 if (fileStream.Read(buffer, 0, HashWindowLength) != HashWindowLength)
                 {
-                    Log.Logger.Error("Error reading from media file : {Name}", MediaFileInfo.Name);
+                    Log.Logger.Error("Error reading from media file : {FileName}", MediaFileInfo.Name);
                     return null;
                 }
 
@@ -512,7 +518,7 @@ namespace PlexCleaner
                 fileStream.Seek(-HashWindowLength, SeekOrigin.End);
                 if (fileStream.Read(buffer, HashWindowLength, HashWindowLength) != HashWindowLength)
                 {
-                    Log.Logger.Error("Error reading from media file : {Name}", MediaFileInfo.Name);
+                    Log.Logger.Error("Error reading from media file : {FileName}", MediaFileInfo.Name);
                     return null;
                 }
 

--- a/PlexCleaner/Tools.cs
+++ b/PlexCleaner/Tools.cs
@@ -75,10 +75,10 @@ namespace PlexCleaner
                 // Query the installed version information
                 if (!mediaTool.GetInstalledVersion(out MediaToolInfo mediaToolInfo))
                 {
-                    Log.Logger.Error("{Tool} not found : {Name}", mediaTool.GetToolType(), mediaTool.GetToolPath());
+                    Log.Logger.Error("{Tool} not found : {FileName}", mediaTool.GetToolType(), mediaTool.GetToolPath());
                     return false;
                 }
-                Log.Logger.Information("{Tool} : Version: {Version}, Path: {Name}", mediaTool.GetToolType(), mediaToolInfo.Version, mediaToolInfo.FileName);
+                Log.Logger.Information("{Tool} : Version: {Version}, Path: {FileName}", mediaTool.GetToolType(), mediaToolInfo.Version, mediaToolInfo.FileName);
 
                 // Assign the tool info
                 mediaTool.Info = mediaToolInfo;
@@ -92,7 +92,7 @@ namespace PlexCleaner
             // Make sure the tools root folder exists
             if (!Directory.Exists(GetToolsRoot()))
             {
-                Log.Logger.Error("Tools directory not found : {Name}", GetToolsRoot());
+                Log.Logger.Error("Tools directory not found : {Directory}", GetToolsRoot());
                 return false;
             }
 
@@ -100,7 +100,7 @@ namespace PlexCleaner
             string toolsfile = GetToolsJsonPath();
             if (!File.Exists(toolsfile))
             {
-                Log.Logger.Error("{Name} not found, run the 'checkfornewtools' command", toolsfile);
+                Log.Logger.Error("{FileName} not found, run the 'checkfornewtools' command", toolsfile);
                 return false;
             }
 
@@ -108,7 +108,7 @@ namespace PlexCleaner
             ToolInfoJsonSchema toolInfoJson = ToolInfoJsonSchema.FromJson(File.ReadAllText(toolsfile));
             if (toolInfoJson.SchemaVersion != ToolInfoJsonSchema.CurrentSchemaVersion)
             {
-                Log.Logger.Error("Tool JSON schema mismatch : {JsonSchemaVersion} != {CurrentSchemaVersion}, {Name}", 
+                Log.Logger.Error("Tool JSON schema mismatch : {JsonSchemaVersion} != {CurrentSchemaVersion}, {FileName}", 
                                  toolInfoJson.SchemaVersion, 
                                  ToolInfoJsonSchema.CurrentSchemaVersion,
                                  toolsfile);
@@ -134,10 +134,10 @@ namespace PlexCleaner
                 if (!File.Exists(mediaTool.GetToolPath()) ||
                     !mediaTool.GetInstalledVersion(out mediaToolInfo))
                 {
-                    Log.Logger.Error("{Tool} not found in path {Name}", mediaTool.GetToolType(), mediaTool.GetToolPath());
+                    Log.Logger.Error("{Tool} not found in path {Directory}", mediaTool.GetToolType(), mediaTool.GetToolPath());
                     return false;
                 }
-                Log.Logger.Information("{Tool} : Version: {Version}, Path: {Name}", 
+                Log.Logger.Information("{Tool} : Version: {Version}, Path: {FileName}", 
                                        mediaTool.GetToolType(), 
                                        mediaToolInfo.Version, 
                                        mediaToolInfo.FileName);
@@ -206,7 +206,7 @@ namespace PlexCleaner
             // 7-Zip must be installed
             if (!File.Exists(SevenZip.GetToolPath()))
             {
-                Log.Logger.Error("{Tool} not found : {Name}", SevenZip.GetToolType(), SevenZip.GetToolPath());
+                Log.Logger.Error("{Tool} not found : {Directory}", SevenZip.GetToolType(), SevenZip.GetToolPath());
                 return false;
             }
 
@@ -279,7 +279,7 @@ namespace PlexCleaner
                         continue;
 
                     // Download the update file in the tools folder
-                    Log.Logger.Information("Downloading {Name} ...", latestToolInfo.FileName);
+                    Log.Logger.Information("Downloading {FileName} ...", latestToolInfo.FileName);
                     string downloadFile = CombineToolPath(latestToolInfo.FileName);
                     if (!Download.DownloadFile(new Uri(latestToolInfo.Url), downloadFile))
                         return false;


### PR DESCRIPTION
- Added `ProcessOptions:RestoreFileTimestamp` JSON option to restore the media file modified time to match the original value.
- Fixed media tool logic to account for MWV files with cover art, and added `wmv3` and `wmav2` codecs to be converted.

Closing #81 
Closing #82 