### PR TITLE
Bump version to 3.17 for next prerelease cycle

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.16",
+  "version": "3.17",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
## Summary

Per the rule documented in AGENTS.md "Develop → Main Promotion" section: after the develop→main promotion (PR #693) shipped `3.16.7` as stable on main, bump develop's minor in [version.json](version.json) from `3.16` to `3.17` so the next NBGV-computed prerelease lands at `3.17.0-g{sha}` — visibly *above* main's `3.16.7` rather than below it.

Isolated PR per the rule's own guidance (no other changes bundled in).

## Test plan

- [ ] CI green
- [ ] Fresh Copilot review on the latest commit
- [ ] Squash-merge into develop
- [ ] After merge, confirm the next develop prerelease tag is `3.17.0-g{sha}` (verify via `gh release list --limit 1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)