### PR TITLE
Bump version to 3.18 for next prerelease cycle

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.17",
+  "version": "3.18",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
Post-promotion minor version bump on `develop`, following the two-phase release of #723 to `main` (via #725).

Bumps `version.json` `3.17` → `3.18` so develop's NBGV prereleases (`3.18.x-g{sha}`) sort above the `3.17.x` stable just shipped — per AGENTS.md "Develop → Main Promotion".

Also serves as the **first real content-change exercise of the two-phase PR workflow**: `version.json` is in the `shared` paths-filter, so this PR triggers the smoke build of both targets (Docker `linux/amd64` + the `linux-x64`/`win-x64` executable subset, no push) alongside unit tests, gated by the `Check pull request workflow status` aggregator.