### PR TITLE
Adopt shared markdownlint config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,7 +37,7 @@ end_of_line = crlf
 indent_size = 2
 
 # Json files
-[*.json]
+[*.{json,jsonc}]
 end_of_line = crlf
 
 # Linux scripts

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,14 @@
+{
+    "config": {
+        // Prose paragraphs and data-heavy tables/URLs are intentionally long;
+        // reflowing at 80 cols hurts readability and churns diffs.
+        "MD013": false,
+        // Inline HTML is used for reference-link section dividers.
+        "MD033": false,
+        // Require fenced code blocks over the legacy 4-space-indented style.
+        "MD046": { "style": "fenced" },
+        // Wide tables are intentional where wrapping cells breaks GitHub rendering.
+        "MD060": false
+    },
+    "gitignore": true
+}


### PR DESCRIPTION
Part of #731 - realign with ptr727/ProjectTemplate.

- Carry the template's [`.markdownlint-cli2.jsonc`](https://github.com/ptr727/ProjectTemplate/blob/main/.markdownlint-cli2.jsonc) **verbatim** so the davidanson `markdownlint` IDE extension and CLI/CI `markdownlint-cli2` apply the same rules.
- Add `jsonc` to the `.editorconfig` `[*.{json,jsonc}]` glob so the config file is CRLF-governed.

Existing docs already pass cleanly under the shared config (`markdownlint-cli2 "**/*.md"` = 0 errors).

**Not included (maintainer discretion):** #731 also suggested aligning the `AGENTS.md` PR-review section *headings* to the template's "PR Review Etiquette" / "Expected Review Loop". On inspection this repo already carries the review-loop contract (under "Merging a PR" / "Develop → Main Promotion") and the Copilot runbook in `.github/copilot-instructions.md`; only the heading names differ. That cosmetic restructuring is left out of this PR to avoid churning maintained docs - can be done separately if desired. Also note: this repo's `.editorconfig` already has the full per-extension `end_of_line` rules (the issue's "crlf only under `[*.md]`" claim was inaccurate), so no EOL-rule change was needed.