### PR TITLE
Revert version to 3.17 to match main

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.18",
+  "version": "3.17",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
Sets `version.json` back to `3.17` so `develop` and `main` carry the same version.

Per the semantic versioning policy, `version.json` is bumped only when the maintainer cuts a real release; `develop` shares `main`'s current version and serves as its prerelease channel.