### PR TITLE
fix: harden interlace detection, skip unreliable checks under quickscan, report seek-index reason (#749)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,8 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
   - Added a deterministic Direct Play verification check ([#746](https://github.com/ptr727/PlexCleaner/issues/746)).
     - Some Matroska files parse cleanly with FfProbe / MkvMerge / MediaInfo yet fail Direct Play in Jellyfin / Emby / Shield because the player cannot use the file's seek index (e.g. the Cues are positioned before the Tracks, which a forward-only reader cannot reach).
     - `Verify` now validates the Matroska seek index (the SeekHead and Cues a player needs for keyframe seeking) using the NEbml library, and remuxes only files whose index is missing or unusable, leaving valid files untouched.
+  - Quickscan accuracy: under `--quickscan` the limited sample is not representative, so interlace detection now skips the unreliable `idet` frame analysis (relying on container interlace flags only) and bitrate verification is skipped, avoiding false-positive deinterlacing of progressive content and unreliable bitrate-exceeded reports ([#749](https://github.com/ptr727/PlexCleaner/issues/749)).
+  - Interlace detection is more conservative to avoid deinterlacing progressive content: it uses idet's more reliable MultiFrame pass and the dominant field order, and only treats content as interlaced when interlaced frames outnumber progressive frames ([#749](https://github.com/ptr727/PlexCleaner/issues/749)).
 - Version 3.16:
   - Structural changes only, no functional changes.
   - Consolidated project structure, build configuration, CI/CD workflows, and Docker configuration across projects.

--- a/PlexCleaner/FfMpegIdetInfo.cs
+++ b/PlexCleaner/FfMpegIdetInfo.cs
@@ -63,7 +63,8 @@ public partial class FfMpegIdetInfo
     public bool IsInterlaced() => IsInterlaced(out _);
 
     public bool IsInterlaced(out double percentage) =>
-        MultiFrame.IsInterlaced(out percentage) || SingleFrame.IsInterlaced(out percentage);
+        // MultiFrame is idet's temporally aware and more reliable detector, SingleFrame is noisier
+        MultiFrame.IsInterlaced(out percentage);
 
     public static bool GetIdetInfo(string fileName, out FfMpegIdetInfo? idetInfo, out string error)
     {
@@ -177,31 +178,26 @@ public partial class FfMpegIdetInfo
 
         public bool IsInterlaced(out double percentage)
         {
-            // Interlaced to total ratio
+            // Genuinely interlaced content is consistently one field order
+            // Use the dominant order and treat the minority order as idet noise
+            int interlaced = Math.Max(Tff, Bff);
             percentage =
                 Total == 0
                     ? 0.0
-                    : System.Convert.ToDouble(Interlaced) / System.Convert.ToDouble(Total) * 100.0;
+                    : System.Convert.ToDouble(interlaced) / System.Convert.ToDouble(Total) * 100.0;
             Debug.Assert(percentage is >= 0.0 and <= 100.0);
 
-            // Less than 50% are determined
+            // Need a determined majority to make a reliable call
             if (Undetermined >= Determined)
             {
                 // Assume not interlaced
                 return false;
             }
 
-            // TODO: What is a reasonable ratio?
-            // Even after deinterlacing the interlaced frame count can still be > 0
-            // 5% or more are interlaced vs. progressive
-            if (Interlaced * 20 >= Progressive)
-            {
-                // Assume interlaced
-                return true;
-            }
-
-            // Assume progressive
-            return false;
+            // Interlaced only when the dominant field order outnumbers progressive frames
+            // Bias toward progressive, a few percent of interlaced frames is normal idet noise
+            // and we would rather miss interlaced content than deinterlace progressive content
+            return interlaced > Progressive;
         }
 
         public void WriteLine(string prefix)

--- a/PlexCleaner/MatroskaStructure.cs
+++ b/PlexCleaner/MatroskaStructure.cs
@@ -36,7 +36,7 @@ internal static class MatroskaStructure
     private const ulong Cues = 0x1C53BB6B;
     private const ulong CuePoint = 0xBB;
 
-    // Returns None when the seek index is usable, else the specific defect(s), i.e. the file should be remuxed
+    // Returns None when the seek index is usable, else the first defect found, i.e. the file should be remuxed
     public static SeekIndexIssue GetSeekIndexIssue(string fileName)
     {
         try

--- a/PlexCleaner/MatroskaStructure.cs
+++ b/PlexCleaner/MatroskaStructure.cs
@@ -12,17 +12,17 @@ namespace PlexCleaner;
 // https://github.com/ietf-wg-cellar/matroska-specification/blob/master/ebml_matroska.xml
 internal static class MatroskaStructure
 {
-    // Seek index validation failures, None means the index is usable
-    [Flags]
+    // Seek index validation failure, None means the index is usable
+    // Validation short-circuits at the first failure so only one value is reported
     public enum SeekIndexIssue
     {
         None = 0,
-        NoSegment = 1 << 0,
-        IncompleteSeekHead = 1 << 1,
-        CuesBeforeTracks = 1 << 2,
-        CuesNotFound = 1 << 3,
-        NoCuePoints = 1 << 4,
-        ParseError = 1 << 5,
+        NoSegment,
+        IncompleteSeekHead,
+        CuesBeforeTracks,
+        CuesNotFound,
+        NoCuePoints,
+        ParseError,
     }
 
     // EBML element IDs (encoded values) from the Matroska specification

--- a/PlexCleaner/MatroskaStructure.cs
+++ b/PlexCleaner/MatroskaStructure.cs
@@ -12,6 +12,19 @@ namespace PlexCleaner;
 // https://github.com/ietf-wg-cellar/matroska-specification/blob/master/ebml_matroska.xml
 internal static class MatroskaStructure
 {
+    // Seek index validation failures, None means the index is usable
+    [Flags]
+    public enum SeekIndexIssue
+    {
+        None = 0,
+        NoSegment = 1 << 0,
+        IncompleteSeekHead = 1 << 1,
+        CuesBeforeTracks = 1 << 2,
+        CuesNotFound = 1 << 3,
+        NoCuePoints = 1 << 4,
+        ParseError = 1 << 5,
+    }
+
     // EBML element IDs (encoded values) from the Matroska specification
     private const ulong Segment = 0x18538067;
     private const ulong SeekHead = 0x114D9B74;
@@ -23,8 +36,8 @@ internal static class MatroskaStructure
     private const ulong Cues = 0x1C53BB6B;
     private const ulong CuePoint = 0xBB;
 
-    // Returns false when the seek index is missing or unusable, i.e. the file should be remuxed
-    public static bool IsSeekIndexValid(string fileName)
+    // Returns None when the seek index is usable, else the specific defect(s), i.e. the file should be remuxed
+    public static SeekIndexIssue GetSeekIndexIssue(string fileName)
     {
         try
         {
@@ -34,21 +47,21 @@ internal static class MatroskaStructure
             // Descend into the Segment, all seek positions are relative to it
             if (!FindElement(reader, Segment))
             {
-                return false;
+                return SeekIndexIssue.NoSegment;
             }
             reader.EnterContainer();
 
             // A usable seek index references the Info, Tracks and Cues elements
             if (!TryReadSeekPositions(reader, out long info, out long tracks, out long cues))
             {
-                return false;
+                return SeekIndexIssue.IncompleteSeekHead;
             }
 
             // A player reads Info and Tracks before seeking forward to the Cues
             // Cues placed before the Tracks or Info cannot be reached and break keyframe seeking
             if (cues < info || cues < tracks)
             {
-                return false;
+                return SeekIndexIssue.CuesBeforeTracks;
             }
 
             // Confirm the Cues element is present at the referenced position and has cue points
@@ -56,7 +69,7 @@ internal static class MatroskaStructure
             _ = reader.ReadAt(cues);
             if (reader.ElementId.EncodedValue != Cues)
             {
-                return false;
+                return SeekIndexIssue.CuesNotFound;
             }
 
             // Confirm at least one cue point is present, an empty index is not usable
@@ -65,12 +78,12 @@ internal static class MatroskaStructure
             bool anyCuePoint = FindElement(reader, CuePoint);
             reader.LeaveContainer();
 
-            return anyCuePoint;
+            return anyCuePoint ? SeekIndexIssue.None : SeekIndexIssue.NoCuePoints;
         }
         catch (Exception e) when (Log.Logger.LogAndHandle(e))
         {
             // Structure too malformed for the reader to parse
-            return false;
+            return SeekIndexIssue.ParseError;
         }
     }
 

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -577,13 +577,13 @@ public class ProcessFile
         }
 
         // Read-only structural check
-        if (MatroskaStructureValid())
+        if (MatroskaStructureValid(out MatroskaStructure.SeekIndexIssue issue))
         {
-            // Can be Direct Played, do not remux valid files
+            // Seek index is usable, do not remux valid files
             return true;
         }
 
-        Log.Warning("Matroska structure cannot be Direct Played : {FileName}", FileInfo.Name);
+        Log.Warning("Matroska seek index unusable, {Issue} : {FileName}", issue, FileInfo.Name);
 
         // Can we repair
         if (!Program.Config.VerifyOptions.AutoRepair || !Program.Config.ProcessOptions.ReMux)
@@ -608,12 +608,15 @@ public class ProcessFile
         }
 
         // Stop if the remux did not fix the structure, else monitor mode loops
-        return MatroskaStructureValid() || SetVerifyFailed("Matroska structure remux");
+        return MatroskaStructureValid(out _) || SetVerifyFailed("Matroska structure remux");
     }
 
-    private bool MatroskaStructureValid() =>
+    private bool MatroskaStructureValid(out MatroskaStructure.SeekIndexIssue issue)
+    {
         // Read-only logical validation of the Matroska seek index
-        MatroskaStructure.IsSeekIndexValid(FileInfo.FullName);
+        issue = MatroskaStructure.GetSeekIndexIssue(FileInfo.FullName);
+        return issue == MatroskaStructure.SeekIndexIssue.None;
+    }
 
     public bool AnyTags() =>
         MkvMergeProps.AnyTags || FfProbeProps.AnyTags || MediaInfoProps.AnyTags;
@@ -962,6 +965,12 @@ public class ProcessFile
         if (videoProps != null)
         {
             // Interlaced attribute set
+            return true;
+        }
+
+        // idet on the limited quickscan sample is unreliable, rely on the interlace metadata flags only
+        if (Program.Options.QuickScan)
+        {
             return true;
         }
 
@@ -1671,6 +1680,12 @@ public class ProcessFile
     {
         // Skip if no bitrate limit
         if (Program.Config.VerifyOptions.MaximumBitrate == 0)
+        {
+            return true;
+        }
+
+        // Bitrate over the limited quickscan sample is not representative of the whole file
+        if (Program.Options.QuickScan)
         {
             return true;
         }

--- a/PlexCleanerTests/FfMpegIdetDecisionTests.cs
+++ b/PlexCleanerTests/FfMpegIdetDecisionTests.cs
@@ -8,19 +8,16 @@ public class FfMpegIdetDecisionTests
 {
     // tff, bff, progressive, undetermined, expectedInterlaced (decision is on the MultiFrame pass)
     [Theory]
-    // Progressive content
-    [InlineData(0, 0, 8992, 0, false)]
-    // Cleanly interlaced, single field order
-    [InlineData(8991, 0, 0, 0, true)]
-    [InlineData(0, 8991, 0, 0, true)]
-    // Progressive with idet noise, real-world false-positive samples, not interlaced
-    [InlineData(206, 111, 3968, 32, false)] // The American (2010)
-    [InlineData(55, 574, 3669, 19, false)] // Top Gun Maverick (2022)
-    [InlineData(332, 397, 3760, 12, false)] // Hysteria (2011)
-    // Mostly undetermined, cannot decide reliably, not interlaced
-    [InlineData(100, 0, 50, 200, false)]
-    // Dominant field order outnumbers progressive frames, interlaced
-    [InlineData(6000, 0, 4000, 0, true)]
+    // Real full-scan idet samples
+    [InlineData(1154, 0, 0, 0, true)] // interlaced, MPEG-2
+    [InlineData(0, 0, 8085, 0, false)] // progressive, clean
+    [InlineData(482, 534, 151645, 23, false)] // progressive feature with idet noise
+    // Synthetic boundary cases
+    [InlineData(8000, 0, 0, 0, true)] // pure top field interlaced
+    [InlineData(0, 8000, 0, 0, true)] // pure bottom field interlaced
+    [InlineData(50, 500, 4000, 0, false)] // minority interlaced noise below progressive
+    [InlineData(100, 0, 50, 200, false)] // undetermined majority, cannot decide
+    [InlineData(6000, 0, 4000, 0, true)] // dominant field order outnumbers progressive
     public void IsInterlaced_MultiFrame(int tff, int bff, int prog, int und, bool expected)
     {
         FfMpegIdetInfo idet = new()

--- a/PlexCleanerTests/FfMpegIdetDecisionTests.cs
+++ b/PlexCleanerTests/FfMpegIdetDecisionTests.cs
@@ -1,0 +1,62 @@
+using AwesomeAssertions;
+using PlexCleaner;
+using Xunit;
+
+namespace PlexCleanerTests;
+
+public class FfMpegIdetDecisionTests
+{
+    // tff, bff, progressive, undetermined, expectedInterlaced (decision is on the MultiFrame pass)
+    [Theory]
+    // Progressive content
+    [InlineData(0, 0, 8992, 0, false)]
+    // Cleanly interlaced, single field order
+    [InlineData(8991, 0, 0, 0, true)]
+    [InlineData(0, 8991, 0, 0, true)]
+    // Progressive with idet noise, real-world false-positive samples, not interlaced
+    [InlineData(206, 111, 3968, 32, false)] // The American (2010)
+    [InlineData(55, 574, 3669, 19, false)] // Top Gun Maverick (2022)
+    [InlineData(332, 397, 3760, 12, false)] // Hysteria (2011)
+    // Mostly undetermined, cannot decide reliably, not interlaced
+    [InlineData(100, 0, 50, 200, false)]
+    // Dominant field order outnumbers progressive frames, interlaced
+    [InlineData(6000, 0, 4000, 0, true)]
+    public void IsInterlaced_MultiFrame(int tff, int bff, int prog, int und, bool expected)
+    {
+        FfMpegIdetInfo idet = new()
+        {
+            MultiFrame = new FfMpegIdetInfo.Frames
+            {
+                Tff = tff,
+                Bff = bff,
+                Progressive = prog,
+                Undetermined = und,
+            },
+        };
+        _ = idet.IsInterlaced().Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsInterlaced_Uses_MultiFrame_Not_SingleFrame()
+    {
+        // SingleFrame looks interlaced but MultiFrame is progressive, the decision follows MultiFrame
+        FfMpegIdetInfo idet = new()
+        {
+            SingleFrame = new FfMpegIdetInfo.Frames
+            {
+                Tff = 8000,
+                Bff = 0,
+                Progressive = 0,
+                Undetermined = 0,
+            },
+            MultiFrame = new FfMpegIdetInfo.Frames
+            {
+                Tff = 0,
+                Bff = 0,
+                Progressive = 8000,
+                Undetermined = 0,
+            },
+        };
+        _ = idet.IsInterlaced().Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Follow-up to the #747/#746 work, validated against the live library.

## Interlace detection (#749)
False-positive deinterlacing of progressive films was observed (e.g. Top Gun Maverick, The Batman, Pacific Rim flagged at 5–16%). Root causes and fixes:
- **Use idet's MultiFrame pass only** (dropped the noisier `MultiFrame || SingleFrame`).
- **Decide from the dominant field order** (`max(TFF, BFF)`) and only when it **outnumbers progressive frames**, replacing the previous `>=5%` ratio. Genuinely interlaced content is consistently one field order at ~100%; a few percent of mixed-order frames is normal idet noise on progressive content.
- Biased toward **not** deinterlacing (prefer a false negative); the manual `deinterlace` command remains the fallback.

## Quickscan accuracy (#749)
Under `--quickscan` only the first 3 minutes are sampled, which is not representative:
- **Skip idet** under quickscan (rely on container interlace flags only).
- **Skip bitrate verification** under quickscan (a 180s sample misrepresents peak/average bitrate).

(`VerifyMediaStreams` and closed-caption detection are left as-is: under quickscan they under-cover but do not produce false positives.)

## Direct Play seek-index message (#746)
Replaced the vague `Matroska structure cannot be Direct Played` log with a specific `SeekIndexIssue` flags enum (`NoSegment`, `IncompleteSeekHead`, `CuesBeforeTracks`, `CuesNotFound`, `NoCuePoints`, `ParseError`) that is logged, so the exact defect is visible.

## Validation
- Local-library run reproduced the deinterlace false positives (15 progressive films); with this change the same idet stats resolve to not-interlaced, while genuine interlaced (consistent single field order) still detects.
- 124 unit tests pass; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)