### PR TITLE
Promote develop to main: publish-dispatch guards and JSON casing fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,7 +36,7 @@ indent_size = 2
 end_of_line = crlf
 indent_size = 2
 
-# Json and JsonC files
+# JSON and JSONC files
 [*.{json,jsonc}]
 end_of_line = crlf
 

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -103,6 +103,21 @@ jobs:
         with:
           ref: ${{ needs.get-version.outputs.GitCommitId }}
 
+      # Safety net: a public (main) release must never carry a prerelease identifier - any '-' in SemVer2 (e.g. the
+      # observed '-g<sha>' git-height suffix). Guards against NBGV mis-detecting the public ref (e.g. a dispatch on a
+      # non-default ref) from publishing a malformed non-prerelease release that GitHub would then mark "Latest".
+      # Root-cause-agnostic backstop to the dispatch-ref guard in publish-release.yml.
+      - name: Verify public release version step
+        if: ${{ inputs.branch == 'main' }}
+        env:
+          SEMVER2: ${{ needs.get-version.outputs.SemVer2 }}
+        run: |
+          set -euo pipefail
+          if [[ "$SEMVER2" == *-* ]]; then
+            echo "::error::Public (main) release version '$SEMVER2' carries a prerelease suffix; refusing to publish."
+            exit 1
+          fi
+
       # Collect every release-asset-<branch>-* artifact by pattern, so the
       # release job never names a build job and stays reusable as targets change.
       - name: Download release asset artifacts step

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -43,6 +43,15 @@ jobs:
           PUBLISH_ON_MERGE: ${{ vars.PUBLISH_ON_MERGE }}
         run: |
           set -euo pipefail
+          # A schedule or dispatch builds BOTH branches in the matrix regardless of the triggering ref (a push builds
+          # only the pushed branch). Dispatching on a non-default ref makes the main leg mis-version (NBGV can't resolve
+          # the public main ref), publishing a malformed non-prerelease release that GitHub marks "Latest". Fail fast:
+          # dispatch only from the default branch.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" \
+                && "${{ github.ref_name }}" != "${{ github.event.repository.default_branch }}" ]]; then
+            echo "::error::Dispatch publish-release from the default branch (${{ github.event.repository.default_branch }}); the matrix builds both branches. Re-dispatch on the default branch."
+            exit 1
+          fi
           case "${{ github.event_name }}" in
             push)
               branches='["${{ github.ref_name }}"]'


### PR DESCRIPTION
Promote the template re-sync from develop to main.

Reincorporates upstream ProjectTemplate fixes ([ptr727/ProjectTemplate#184](https://github.com/ptr727/ProjectTemplate/pull/184) / [#185](https://github.com/ptr727/ProjectTemplate/pull/185)) that resolved the publish-dispatch mis-versioning defect surfaced while re-syncing this downstream.

- **`publish-release.yml`**: fail fast on a non-default-ref dispatch (the matrix builds both branches; a non-default dispatch mis-versions the `main` leg).
- **`build-release-task.yml`**: refuse a `main` release whose `SemVer2` carries a prerelease suffix (safety-net backstop).
- **`.editorconfig`**: correct JSON/JSONC casing in the section comment.

Workflow/governance changes only; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)