### PR TITLE
Promote: float dotnet/nbgv on @master

### DIFF
--- a/.github/workflows/get-version-task.yml
+++ b/.github/workflows/get-version-task.yml
@@ -49,6 +49,8 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
+      # Float nbgv on `master`, not SHA-pinned: its tag stream lags `master`, so Dependabot
+      # tag-tracking would only propose downgrades to stale tags (WORKFLOW.md D9.1).
       - name: Run Nerdbank.GitVersioning tool step
         id: nbgv
-        uses: dotnet/nbgv@705dad19ab067f12f4e9eeaa60812e01edef5d25 # v0.5.2
+        uses: dotnet/nbgv@master

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Versioning is the one release rule that is a **human process**, not a workflow o
 - The `version` (major.minor) in [`version.json`](./version.json) is the version floor; NBGV appends the git height as the SemVer patch. `main` (the public release ref, `publicReleaseRefSpec = ^refs/heads/main$`) builds a stable `X.Y.<height>`; `develop` builds a prerelease `X.Y.<height>-g<sha>`. The maintainer edits `version.json`; *routine* dependency bumps, CI/workflow fixes, and doc edits leave it untouched.
 - **Bump `version.json` only by maintainer instruction**, for a functional change (a new feature, a behavior change, a breaking change) or a significant one-time overhaul of the build/release process (such as a CI/CD migration), in the PR that introduces it (typically on `develop`). Do not bump on a cadence, for routine CI/workflow or dependency or doc edits, or mechanically after a release.
 - **No post-release bump; no develop-ahead requirement.** NBGV advances the patch on every commit, so a release always gets a fresh build version with no `version.json` edit and there is no `bump-version-X.Y` PR after a release. A `develop -> main` promotion carries whatever `version.json` is current.
+- **`dotnet/nbgv` is consumed via `@master`, never SHA-pinned.** Its tag stream lags `master` such that Dependabot tag-tracking would only propose downgrades to stale tags; this is the sole WORKFLOW.md D9.1 exception (rationale inline in the workflow). Do not SHA-pin it.
 
 ## Pull Request Title and Commit Message Conventions
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,11 +3,11 @@
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="CliWrap" Version="3.10.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="InsaneGenius.Utilities" Version="3.5.6" />
+    <PackageVersion Include="InsaneGenius.Utilities" Version="3.6.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="NEbml" Version="1.1.0.5" />
-    <PackageVersion Include="ptr727.LanguageTags" Version="1.3.11" />
+    <PackageVersion Include="ptr727.LanguageTags" Version="1.5.6" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -300,7 +300,7 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
 
 ### D9 - Style, static, and dropped workflows (see section 2)
 
-- **D9.1** Every action SHA-pinned with a version comment; an installed-tool version (e.g. the actionlint
+- **D9.1** Every action SHA-pinned with a version comment (sole exception: `dotnet/nbgv@master`); an installed-tool version (e.g. the actionlint
   binary) is left unpinned to track latest.
 - **D9.2** File/workflow/job/step names follow the suffix rules; a ruleset-bound `context:` name moves only in
   lockstep with `repo-config/`.


### PR DESCRIPTION
Promotes the nbgv @master change: get-version-task.yml floats `dotnet/nbgv@master` (was the v0.5.2 SHA pin), WORKFLOW.md D9.1 records it as the sole SHA-pin exception, and AGENTS.md carries the accurate tag-lag rationale. No-bypass merge-commit promotion.