### PR TITLE
Validate --pluginassembly at parse time with a native FileInfo option

### DIFF
--- a/PlexCleaner/CommandLineOptions.cs
+++ b/PlexCleaner/CommandLineOptions.cs
@@ -132,18 +132,24 @@ public class CommandLineParser
     };
 
     // FileInfo with AcceptExistingOnly validates the path exists at parse time, so the plugin loader
-    // does not need to re-check it
+    // does not need to re-check it. Both Required and the existence check are gated to non-AOT builds so
+    // that under AOT the custom command still reaches CustomCommand and emits the non-AOT error.
+#if PLUGINS
     private readonly Option<FileInfo> _pluginAssemblyOption = new Option<FileInfo>(
         "--pluginassembly"
     )
     {
         Description = "Path to a plugin assembly implementing IProcessPlugin",
         HelpName = "filepath",
-        // Not required in AOT builds so custom can reach CustomCommand and emit the non-AOT error
-#if PLUGINS
         Required = true,
-#endif
     }.AcceptExistingOnly();
+#else
+    private readonly Option<FileInfo> _pluginAssemblyOption = new("--pluginassembly")
+    {
+        Description = "Path to a plugin assembly implementing IProcessPlugin",
+        HelpName = "filepath",
+    };
+#endif
 
     private RootCommand CreateRootCommand()
     {

--- a/PlexCleaner/CommandLineOptions.cs
+++ b/PlexCleaner/CommandLineOptions.cs
@@ -19,7 +19,7 @@ public class CommandLineOptions
     public string ResultsFile { get; set; } = string.Empty;
     public string SchemaFile { get; set; } = string.Empty;
     public string SettingsFile { get; set; } = string.Empty;
-    public string PluginAssembly { get; set; } = string.Empty;
+    public FileInfo? PluginAssembly { get; set; }
 }
 
 public class CommandLineParser
@@ -131,7 +131,11 @@ public class CommandLineParser
         HelpName = "boolean",
     };
 
-    private readonly Option<string> _pluginAssemblyOption = new("--pluginassembly")
+    // FileInfo with AcceptExistingOnly validates the path exists at parse time, so the plugin loader
+    // does not need to re-check it
+    private readonly Option<FileInfo> _pluginAssemblyOption = new Option<FileInfo>(
+        "--pluginassembly"
+    )
     {
         Description = "Path to a plugin assembly implementing IProcessPlugin",
         HelpName = "filepath",
@@ -139,7 +143,7 @@ public class CommandLineParser
 #if PLUGINS
         Required = true,
 #endif
-    };
+    }.AcceptExistingOnly();
 
     private RootCommand CreateRootCommand()
     {
@@ -440,7 +444,7 @@ public class CommandLineParser
             ResultsFile = Result.GetValue(_resultsFileOption) ?? string.Empty,
             SchemaFile = Result.GetValue(_schemaFileOption) ?? string.Empty,
             SettingsFile = Result.GetValue(_settingsFileOption) ?? string.Empty,
-            PluginAssembly = Result.GetValue(_pluginAssemblyOption) ?? string.Empty,
+            PluginAssembly = Result.GetValue(_pluginAssemblyOption),
         };
 
         return options;

--- a/PlexCleaner/PluginLoader.cs
+++ b/PlexCleaner/PluginLoader.cs
@@ -61,11 +61,11 @@ public static class PluginLoader
     [RequiresDynamicCode("Loads a plugin assembly at runtime")]
     public static IProcessPlugin? Load(FileInfo assemblyFile)
     {
-        // The CLI validates that the path exists (AcceptExistingOnly), so use the resolved full path
-        // directly and let the try/catch handle assembly load and reflection errors
-        string fullPath = assemblyFile.FullName;
+        // The CLI validates that the path exists (AcceptExistingOnly), so just load and reflect. Resolve
+        // FullName inside the try so any path error is logged and returns null instead of throwing.
         try
         {
+            string fullPath = assemblyFile.FullName;
             PluginLoadContext context = new(fullPath);
             Assembly assembly = context.LoadFromAssemblyPath(fullPath);
 
@@ -107,8 +107,8 @@ public static class PluginLoader
         }
         catch (Exception e) when (Log.Logger.LogAndHandle(e))
         {
-            // Include the assembly path since LogAndHandle only reports the caller member
-            Log.Error("Failed to load plugin : {AssemblyPath}", fullPath);
+            // Log the file name (does not resolve the path) since LogAndHandle only reports the caller
+            Log.Error("Failed to load plugin : {AssemblyName}", assemblyFile.Name);
             return null;
         }
     }

--- a/PlexCleaner/PluginLoader.cs
+++ b/PlexCleaner/PluginLoader.cs
@@ -63,13 +63,14 @@ public static class PluginLoader
     {
         ArgumentNullException.ThrowIfNull(assemblyFile);
 
-        // The CLI validates that the path exists (AcceptExistingOnly), so just load and reflect. Resolve
-        // FullName inside the try so any path error is logged and returns null instead of throwing.
+        // Start with the safe file name and upgrade to the resolved full path inside the try, so the
+        // catch can log the most specific location available without FullName throwing before the try
+        string assemblyPath = assemblyFile.Name;
         try
         {
-            string fullPath = assemblyFile.FullName;
-            PluginLoadContext context = new(fullPath);
-            Assembly assembly = context.LoadFromAssemblyPath(fullPath);
+            assemblyPath = assemblyFile.FullName;
+            PluginLoadContext context = new(assemblyPath);
+            Assembly assembly = context.LoadFromAssemblyPath(assemblyPath);
 
             // Require exactly one concrete IProcessPlugin implementation
             List<Type> pluginTypes =
@@ -86,7 +87,7 @@ public static class PluginLoader
                 Log.Error(
                     "Plugin assembly must contain exactly one IProcessPlugin implementation, found {Count} : {AssemblyPath}",
                     pluginTypes.Count,
-                    fullPath
+                    assemblyPath
                 );
                 return null;
             }
@@ -104,13 +105,14 @@ public static class PluginLoader
                 return null;
             }
 
-            Log.Information("Loaded plugin : {Name} : {AssemblyPath}", plugin.Name, fullPath);
+            Log.Information("Loaded plugin : {Name} : {AssemblyPath}", plugin.Name, assemblyPath);
             return plugin;
         }
         catch (Exception e) when (Log.Logger.LogAndHandle(e))
         {
-            // Log the file name (does not resolve the path) since LogAndHandle only reports the caller
-            Log.Error("Failed to load plugin : {AssemblyName}", assemblyFile.Name);
+            // Log the resolved path (falls back to the file name if FullName threw) since LogAndHandle
+            // only reports the caller member
+            Log.Error("Failed to load plugin : {AssemblyPath}", assemblyPath);
             return null;
         }
     }

--- a/PlexCleaner/PluginLoader.cs
+++ b/PlexCleaner/PluginLoader.cs
@@ -61,6 +61,8 @@ public static class PluginLoader
     [RequiresDynamicCode("Loads a plugin assembly at runtime")]
     public static IProcessPlugin? Load(FileInfo assemblyFile)
     {
+        ArgumentNullException.ThrowIfNull(assemblyFile);
+
         // The CLI validates that the path exists (AcceptExistingOnly), so just load and reflect. Resolve
         // FullName inside the try so any path error is logged and returns null instead of throwing.
         try

--- a/PlexCleaner/PluginLoader.cs
+++ b/PlexCleaner/PluginLoader.cs
@@ -59,26 +59,13 @@ public static class PluginLoader
         "Loads a plugin assembly and discovers IProcessPlugin via reflection"
     )]
     [RequiresDynamicCode("Loads a plugin assembly at runtime")]
-    public static IProcessPlugin? Load(string assemblyPath)
+    public static IProcessPlugin? Load(FileInfo assemblyFile)
     {
-        // An empty path would resolve to the current directory and report a misleading error
-        if (string.IsNullOrWhiteSpace(assemblyPath))
-        {
-            Log.Error("Plugin assembly path is empty");
-            return null;
-        }
-
-        // Resolve inside the try so a malformed path (GetFullPath throws) fails cleanly with a log
-        string fullPath = assemblyPath;
+        // The CLI validates that the path exists (AcceptExistingOnly), so use the resolved full path
+        // directly and let the try/catch handle assembly load and reflection errors
+        string fullPath = assemblyFile.FullName;
         try
         {
-            fullPath = Path.GetFullPath(assemblyPath);
-            if (!File.Exists(fullPath))
-            {
-                Log.Error("Plugin assembly not found : {AssemblyPath}", fullPath);
-                return null;
-            }
-
             PluginLoadContext context = new(fullPath);
             Assembly assembly = context.LoadFromAssemblyPath(fullPath);
 

--- a/PlexCleaner/Program.cs
+++ b/PlexCleaner/Program.cs
@@ -285,7 +285,12 @@ public static class Program
             return MakeExitCode(ExitCode.Error);
         }
 
-        // Load the plugin after config and tools are initialized
+        // Load the plugin after config and tools are initialized (the option is required, so the
+        // path is always present here)
+        if (Options.PluginAssembly == null)
+        {
+            return MakeExitCode(ExitCode.Error);
+        }
         IProcessPlugin? plugin = PluginLoader.Load(Options.PluginAssembly);
         if (plugin == null)
         {

--- a/PlexCleaner/Program.cs
+++ b/PlexCleaner/Program.cs
@@ -289,6 +289,7 @@ public static class Program
         // path is always present here)
         if (Options.PluginAssembly == null)
         {
+            Log.Error("Plugin assembly path is required");
             return MakeExitCode(ExitCode.Error);
         }
         IProcessPlugin? plugin = PluginLoader.Load(Options.PluginAssembly);

--- a/PlexCleanerTests/CommandLineTests.cs
+++ b/PlexCleanerTests/CommandLineTests.cs
@@ -383,6 +383,45 @@ public class CommandLineTests
         _ = options.ThreadCount.Should().Be(2);
     }
 
+    [Fact]
+    public void Parse_Commandline_Custom_ExistingPluginAssembly_Binds()
+    {
+        // AcceptExistingOnly validates the path at parse time, so use a file that exists
+        string existing = typeof(CommandLineTests).Assembly.Location;
+        string[] args =
+        [
+            "custom",
+            "--settingsfile=settings.json",
+            $"--pluginassembly={existing}",
+            "--mediafiles=/data/foo",
+        ];
+
+        CommandLineParser parser = new(args);
+        _ = parser.Result.Errors.Should().BeEmpty();
+        _ = parser.Result.CommandResult.Command.Name.Should().Be("custom");
+
+        CommandLineOptions options = parser.Bind();
+        FileInfo? pluginAssembly = options.PluginAssembly;
+        _ = pluginAssembly.Should().NotBeNull();
+        _ = pluginAssembly.FullName.Should().Be(new FileInfo(existing).FullName);
+    }
+
+    [Fact]
+    public void Parse_Commandline_Custom_MissingPluginAssembly_Fails()
+    {
+        // A non-existent plugin path fails at parse time via AcceptExistingOnly
+        string[] args =
+        [
+            "custom",
+            "--settingsfile=settings.json",
+            "--pluginassembly=/does/not/exist.dll",
+            "--mediafiles=/data/foo",
+        ];
+
+        CommandLineParser parser = new(args);
+        _ = parser.Result.Errors.Should().NotBeEmpty();
+    }
+
     [Theory]
     [InlineData("--help")]
     [InlineData("--version")]

--- a/PlexCleanerTests/PluginLoaderTests.cs
+++ b/PlexCleanerTests/PluginLoaderTests.cs
@@ -12,7 +12,7 @@ public class PluginLoaderTests
     [Fact]
     public void Load_ExamplePlugin_ReturnsInitializedPlugin()
     {
-        IProcessPlugin? plugin = PluginLoader.Load(ExamplePluginPath);
+        IProcessPlugin? plugin = PluginLoader.Load(new FileInfo(ExamplePluginPath));
 
         // A non-null typed return proves the loaded type satisfies the host's IProcessPlugin
         // (single shared type identity) and that Initialize accepted the host
@@ -26,7 +26,7 @@ public class PluginLoaderTests
     public void Load_MissingAssembly_ReturnsNull()
     {
         IProcessPlugin? plugin = PluginLoader.Load(
-            Path.Combine(AppContext.BaseDirectory, "DoesNotExist.dll")
+            new FileInfo(Path.Combine(AppContext.BaseDirectory, "DoesNotExist.dll"))
         );
 
         _ = plugin.Should().BeNull();


### PR DESCRIPTION
## Summary

Follow-up to #791. Converts the `--pluginassembly` option from `string` to a native `Option<FileInfo>` with `AcceptExistingOnly()`, so a missing plugin path fails at **argument parsing** with a clear `File does not exist` message before the command handler runs.

This lets `PluginLoader.Load` take a `FileInfo` and drop its manual validation — the empty-path check, `Path.GetFullPath`, and `File.Exists` guards are removed (the CLI now guarantees an existing, resolved path). The remaining `try/catch` covers genuine assembly-load/reflection errors only.

## Scope

Deliberately limited to `--pluginassembly`, the one path option that is a pure input whose validation this actually removes:

- `--mediafiles` — `GetFiles` still needs its `try/catch` for enumeration/permission/cancellation, so a native type would only add a `FileSystemInfo`→`string` conversion without removing code (and the collection `AcceptExistingOnly` support is inconsistent). Left as `List<string>`.
- `--settingsfile` / `--schemafile` — write paths for `defaultsettings`/`createschema`, so must-exist would be wrong. Unchanged.

## Testing

- Build clean (0 warnings, `TreatWarningsAsErrors`), format clean, full suite green (162).
- Parse-time validation verified: `--pluginassembly /no/such.dll` → `File does not exist: '/no/such.dll'.`, exit 1, before the handler.
- Happy path verified end to end: the example plugin loads and runs (exit 0).

No version bump (part of unreleased 3.20).