### PR TITLE
Fix --logwarning log flood and log repair detections as warnings

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 
 - Version 3.20:
   - Added per-file stateful log level filtering to enable information level output after a warning or error event is detected, overriding the `--logwarning` warning only filter. Prior to this change the log output would only contain the trigger warning or error event, now it will also log all subsequent information level events for that file during its processing cycle.
+  - Log a warning when a repair or cleanup condition is detected (redundant `Default` flags, invalid language tags, interlaced video, tracks needing re-encode, etc.) so `--logwarning` surfaces every file that is modified, with the subsequent cleanup steps logged at information level.
   - Always log the end-of-run summary at information level, even with `--logwarning`, so the modified, error, and verify-failed counts are recorded for every processing run.
   - Handle the `SIGINT`, `SIGTERM`, and `SIGQUIT` termination signals (`docker stop`, `Ctrl+C`) so processing is interrupted gracefully and the summary and exit code are logged before exit. The custom `Ctrl+Q`/`Ctrl+Z` exit keys are removed in favor of the standard signals.
   - Normalize `Default` track flags instead of only warning about them: clear the flag on a lone track of a type, keep the preferred audio track as the single default when multiple are flagged, and clear all default flags on subtitle tracks.

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -406,15 +406,13 @@ public class ProcessFile
         // Per MkvToolNix docs remux is the recommended approach to correcting language tags
         // Honor Program.Config.ProcessOptions.SetIetfLanguageTags as lots of older media does not have IETF tags set
 
-        // Any tracks need remuxing
-        if (
-            !HasMetadataErrors(TrackProps.StateType.Remove)
-            && !HasMetadataErrors(TrackProps.StateType.ReMux)
-            && !(
-                Program.Config.ProcessOptions.SetIetfLanguageTags
-                && HasMetadataErrors(TrackProps.StateType.SetLanguage)
-            )
-        )
+        // Any tracks need remuxing, evaluate each once and reuse for the detection warning
+        bool removeErrors = HasMetadataErrors(TrackProps.StateType.Remove);
+        bool remuxErrors = HasMetadataErrors(TrackProps.StateType.ReMux);
+        bool setLanguageErrors =
+            Program.Config.ProcessOptions.SetIetfLanguageTags
+            && HasMetadataErrors(TrackProps.StateType.SetLanguage);
+        if (!removeErrors && !remuxErrors && !setLanguageErrors)
         {
             // Done
             return true;
@@ -444,9 +442,9 @@ public class ProcessFile
         // Detected: metadata errors requiring a remux
         Log.Warning(
             "Metadata errors detected : Remove: {Remove}, ReMux: {ReMux}, SetLanguage: {SetLanguage} : {FileName}",
-            HasMetadataErrors(TrackProps.StateType.Remove),
-            HasMetadataErrors(TrackProps.StateType.ReMux),
-            HasMetadataErrors(TrackProps.StateType.SetLanguage),
+            removeErrors,
+            remuxErrors,
+            setLanguageErrors,
             FileInfo.Name
         );
 

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -560,7 +560,9 @@ public class ProcessFile
         // Detected: tracks needing flags set
         Log.Warning(
             "Track flags to set detected : Tracks: {Tracks} : {FileName}",
-            MkvMergeProps.GetTrackList().Count(item => item.State == TrackProps.StateType.SetFlags),
+            MkvMergeProps.Video.Count(item => item.State == TrackProps.StateType.SetFlags)
+                + MkvMergeProps.Audio.Count(item => item.State == TrackProps.StateType.SetFlags)
+                + MkvMergeProps.Subtitle.Count(item => item.State == TrackProps.StateType.SetFlags),
             FileInfo.Name
         );
 

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -142,6 +142,13 @@ public class ProcessFile
             return true;
         }
 
+        // Detected: extension in the ReMux extension list
+        Log.Warning(
+            "ReMux extension detected : Extension: {Extension} : {FileName}",
+            FileInfo.Extension,
+            FileInfo.Name
+        );
+
         // ReMux the file
         Log.Information("Remux file matched by extension : {FileName}", FileInfo.Name);
 
@@ -328,6 +335,13 @@ public class ProcessFile
             return true;
         }
 
+        // Detected: tracks with invalid language tags
+        Log.Warning(
+            "Invalid language tags detected : Tracks: {Tracks} : {FileName}",
+            selectMediaProps.Selected.Count,
+            FileInfo.Name
+        );
+
         Log.Information("Setting invalid language tags : {FileName}", FileInfo.Name);
         selectMediaProps.WriteLine("Invalid", "Keep");
 
@@ -427,6 +441,15 @@ public class ProcessFile
 
         // Do not call SetState() on items that are not in scope, further processing is done by state
 
+        // Detected: metadata errors requiring a remux
+        Log.Warning(
+            "Metadata errors detected : Remove: {Remove}, ReMux: {ReMux}, SetLanguage: {SetLanguage} : {FileName}",
+            HasMetadataErrors(TrackProps.StateType.Remove),
+            HasMetadataErrors(TrackProps.StateType.ReMux),
+            HasMetadataErrors(TrackProps.StateType.SetLanguage),
+            FileInfo.Name
+        );
+
         // ReMux the file
         Log.Information("Remux to repair metadata errors : {FileName}", FileInfo.Name);
         selectMediaProps.WriteLine("Keep", "Remove");
@@ -496,6 +519,13 @@ public class ProcessFile
         // To be removed tracks
         selectMediaProps.Move(mkvMergeRemoveList, false);
 
+        // Detected: multiple video tracks
+        Log.Warning(
+            "Extra video tracks detected : Video: {Video} : {FileName}",
+            MkvMergeProps.Video.Count,
+            FileInfo.Name
+        );
+
         // ReMux the file
         Log.Information("Remux to remove extra video tracks : {FileName}", FileInfo.Name);
         selectMediaProps.WriteLine("Keep", "Remove");
@@ -526,6 +556,13 @@ public class ProcessFile
             // Nothing to do
             return true;
         }
+
+        // Detected: tracks needing flags set
+        Log.Warning(
+            "Track flags to set detected : Tracks: {Tracks} : {FileName}",
+            MkvMergeProps.GetTrackList().Count(item => item.State == TrackProps.StateType.SetFlags),
+            FileInfo.Name
+        );
 
         // Already flagged?
         if (_sidecarFile.State.HasFlag(SidecarFile.StatesType.SetFlags))
@@ -571,6 +608,15 @@ public class ProcessFile
             // Nothing to do
             return true;
         }
+
+        // Detected: redundant Default flags, report the Default-flagged track count per type
+        Log.Warning(
+            "Redundant Default flags detected : Video: {Video}, Audio: {Audio}, Subtitle: {Subtitle} : {FileName}",
+            MkvMergeProps.Video.Count(item => item.Flags.HasFlag(TrackProps.FlagsType.Default)),
+            MkvMergeProps.Audio.Count(item => item.Flags.HasFlag(TrackProps.FlagsType.Default)),
+            MkvMergeProps.Subtitle.Count(item => item.Flags.HasFlag(TrackProps.FlagsType.Default)),
+            FileInfo.Name
+        );
 
         // Re-detected after a previous clearing pass, e.g. reintroduced by re-encoding
         if (_sidecarFile.State.HasFlag(SidecarFile.StatesType.ClearedDefaultFlags))
@@ -721,6 +767,9 @@ public class ProcessFile
             return true;
         }
 
+        // Detected: tags present
+        Log.Warning("Tags detected : {FileName}", FileInfo.Name);
+
         // Already cleared?
         // Tags can re-appear after running FfMpeg or HandBrake
         if (_sidecarFile.State.HasFlag(SidecarFile.StatesType.ClearedTags))
@@ -752,6 +801,13 @@ public class ProcessFile
             // No attachments
             return true;
         }
+
+        // Detected: attachments present
+        Log.Warning(
+            "Attachments detected : Attachments: {Attachments} : {FileName}",
+            MkvMergeProps.Attachments,
+            FileInfo.Name
+        );
 
         // Already removed?
         if (_sidecarFile.State.HasFlag(SidecarFile.StatesType.RemovedAttachments))
@@ -870,6 +926,9 @@ public class ProcessFile
             return true;
         }
 
+        // Detected: cover art present
+        Log.Warning("Cover Art detected : {FileName}", FileInfo.Name);
+
         // Already removed?
         if (_sidecarFile.State.HasFlag(SidecarFile.StatesType.RemovedCoverArt))
         {
@@ -924,6 +983,13 @@ public class ProcessFile
             return true;
         }
 
+        // Detected: tracks with unknown language
+        Log.Warning(
+            "Unknown language tracks detected : Tracks: {Tracks} : {FileName}",
+            selectMediaProps.Selected.Count,
+            FileInfo.Name
+        );
+
         Log.Information(
             "Setting unknown language tracks to {DefaultLanguage} : {FileName}",
             Program.Config.ProcessOptions.DefaultLanguage,
@@ -970,6 +1036,13 @@ public class ProcessFile
         // There must be something left to keep
         Debug.Assert(selectMediaProps.Selected.Count > 0);
 
+        // Detected: tracks with unwanted languages
+        Log.Warning(
+            "Unwanted language tracks detected : Tracks: {Tracks} : {FileName}",
+            selectMediaProps.NotSelected.Count,
+            FileInfo.Name
+        );
+
         Log.Information("Removing unwanted language tracks : {FileName}", FileInfo.Name);
         selectMediaProps.WriteLine("Keep", "Remove");
 
@@ -1006,6 +1079,13 @@ public class ProcessFile
 
         // There must be something left to keep
         Debug.Assert(selectMediaProps.Selected.Count > 0);
+
+        // Detected: duplicate tracks
+        Log.Warning(
+            "Duplicate tracks detected : Tracks: {Tracks} : {FileName}",
+            selectMediaProps.NotSelected.Count,
+            FileInfo.Name
+        );
 
         Log.Information("Removing duplicate tracks : {FileName}", FileInfo.Name);
         selectMediaProps.WriteLine("Keep", "Remove");
@@ -1181,6 +1261,13 @@ public class ProcessFile
             return true;
         }
 
+        // Detected: interlaced video
+        Log.Warning(
+            "Interlaced video detected : Format: {Format} : {FileName}",
+            videoProps.Format,
+            FileInfo.Name
+        );
+
         // Already deinterlaced?
         if (State.HasFlag(SidecarFile.StatesType.DeInterlaced))
         {
@@ -1335,6 +1422,13 @@ public class ProcessFile
             return true;
         }
 
+        // Detected: closed captions in the video stream
+        Log.Warning(
+            "Closed Captions detected : Format: {Format} : {FileName}",
+            videoProps.Format,
+            FileInfo.Name
+        );
+
         // Already removed?
         if (_sidecarFile.State.HasFlag(SidecarFile.StatesType.ClearedCaptions))
         {
@@ -1421,6 +1515,13 @@ public class ProcessFile
             return true;
         }
 
+        // Detected: subtitle tracks present
+        Log.Warning(
+            "Subtitles detected : Subtitle: {Subtitle} : {FileName}",
+            MkvMergeProps.Subtitle.Count,
+            FileInfo.Name
+        );
+
         Log.Information("Removing subtitles : {FileName}", FileInfo.Name);
         MkvMergeProps.Subtitle.ForEach(item => item.WriteLine("Subtitles"));
 
@@ -1465,6 +1566,13 @@ public class ProcessFile
             // Done
             return true;
         }
+
+        // Detected: tracks requiring re-encoding
+        Log.Warning(
+            "Tracks requiring re-encode detected : Tracks: {Tracks} : {FileName}",
+            selectMediaProps.Selected.Count,
+            FileInfo.Name
+        );
 
         // Already reencoded?
         if (State.HasFlag(SidecarFile.StatesType.ReEncoded))

--- a/PlexCleaner/SidecarFile.cs
+++ b/PlexCleaner/SidecarFile.cs
@@ -44,7 +44,6 @@ public class SidecarFile
     private string _mkvMergeJson = string.Empty;
 
     private SidecarFileJsonSchema? _sidecarJson;
-    private StatesType _state;
 
     public SidecarFile(FileInfo mediaFileInfo)
     {
@@ -72,19 +71,7 @@ public class SidecarFile
     public MediaProps MkvMergeProps { get; private set; }
     public MediaProps MediaInfoProps { get; private set; }
 
-    public StatesType State
-    {
-        get => _state;
-        set
-        {
-            // Elevate loglevel
-            if (value != StatesType.None && value != _state)
-            {
-                PerFileLogLevel.Elevate();
-            }
-            _state = value;
-        }
-    }
+    public StatesType State { get; set; }
 
     public bool Create()
     {
@@ -321,8 +308,7 @@ public class SidecarFile
         MkvMergeProps = mkvMergeProps;
         FfProbeProps = ffProbeProps;
 
-        // Set state directly to prevent log elevation
-        _state = _sidecarJson.State;
+        State = _sidecarJson.State;
 
         return true;
     }

--- a/PlexCleanerTests/PerFileLogLevelTests.cs
+++ b/PlexCleanerTests/PerFileLogLevelTests.cs
@@ -155,41 +155,15 @@ public class PerFileLogLevelTests
     }
 
     [Fact]
-    public void SidecarStateChange_ElevatesSession()
+    public void SidecarStateChange_DoesNotElevate()
     {
+        // State changes no longer elevate logging; only Warning/Error events do. Detections are logged
+        // as explicit warnings, which is what raises the per-file level.
         PerFileLogLevel.Filter filter = new(LogEventLevel.Warning);
         SidecarFile sidecar = new("/does-not-exist.mkv");
         using IDisposable scope = PerFileLogLevel.BeginScope(LogEventLevel.Warning);
 
         _ = filter.IsEnabled(Event(LogEventLevel.Information)).Should().BeFalse();
-        sidecar.State = SidecarFile.StatesType.ReMuxed;
-        _ = filter.IsEnabled(Event(LogEventLevel.Information)).Should().BeTrue();
-    }
-
-    [Fact]
-    public void SidecarStateNone_DoesNotElevate()
-    {
-        PerFileLogLevel.Filter filter = new(LogEventLevel.Warning);
-        SidecarFile sidecar = new("/does-not-exist.mkv");
-        using IDisposable scope = PerFileLogLevel.BeginScope(LogEventLevel.Warning);
-
-        sidecar.State = SidecarFile.StatesType.None;
-        _ = filter.IsEnabled(Event(LogEventLevel.Information)).Should().BeFalse();
-    }
-
-    [Fact]
-    public void SidecarStateUnchanged_DoesNotElevate()
-    {
-        PerFileLogLevel.Filter filter = new(LogEventLevel.Warning);
-        SidecarFile sidecar = new("/does-not-exist.mkv");
-
-        // First assignment elevates a throwaway session; re-setting the same value must not elevate
-        using (PerFileLogLevel.BeginScope(LogEventLevel.Warning))
-        {
-            sidecar.State = SidecarFile.StatesType.ReMuxed;
-        }
-
-        using IDisposable scope = PerFileLogLevel.BeginScope(LogEventLevel.Warning);
         sidecar.State = SidecarFile.StatesType.ReMuxed;
         _ = filter.IsEnabled(Event(LogEventLevel.Information)).Should().BeFalse();
     }


### PR DESCRIPTION
## Problem

Under `--logwarning`, the log was flooded with information-level output for files that had no warning or error — a real run showed **2869 of 2899 files** emitting full INF with zero WRN/ERR. The `Default` flag detection had also regressed from a warning to information, so `--logwarning` no longer surfaced files being modified.

## Root cause (proven by instrumentation)

The per-file log elevation was triggered by the `SidecarFile.State` **setter** calling `PerFileLogLevel.Elevate()` on every non-`None` state change. Since nearly every file gets `Verified` and/or `ClearedDefaultFlags` (the new lone-track default logic clears flags on almost every file), nearly every file elevated its session → `--logwarning` was defeated.

Instrumenting `Elevate()` produced the smoking gun — the state change fires *before* the leaked INF:

```
[WRN] TRACE-ELEVATE-STATE: None -> ClearedDefaultFlags : "f.mkv"   ← elevation
[INF] Reading media info from tools : "f.mkv"                       ← now visible
[INF] MediaInfo : Video ...
```

It also explains why `ClearedDefaultFlags` appeared in state with no clearing log: `Clearing redundant Default flags` is logged at INF *before* the state is set, so it was suppressed while the state set elevated everything after it.

## Fix

- **Revert `SidecarFile.State` to a plain auto-property** — only warning/error events elevate the per-file level, as designed.
- **Detect → warning, cleanup → information.** Each repair method now logs a `Log.Warning` at the point it *detects* a condition needing action, with rich context, keeping the cleanup steps at information (elevated by the detection warning). Restores the `Default` flag detection warning (with per-track-type counts) and makes `--logwarning` surface every modified file. Applied consistently across ~15 repair methods (matching the existing `RepairMatroskaStructure` shape). `Log.Error` calls are unchanged.
- Replace the log-level tests that asserted state-change elevation with a test asserting state changes no longer elevate.

## Verification

- Full suite green (162).
- `--logwarning` on a fresh file → WRN detect lines (e.g. `Redundant Default flags detected : Video: 1, Audio: 1, Subtitle: 0`) + elevated INF cleanup.
- `--logwarning` re-run on the now-clean file → **zero** per-file INF/WRN (only the always-on banner/summary).

Fixes an unreleased 3.20 regression; no version bump.