### PR TITLE
Show default/total track counts in the default-flags detection warning

### DIFF
--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -609,12 +609,16 @@ public class ProcessFile
             return true;
         }
 
-        // Detected: redundant Default flags, report the Default-flagged track count per type
+        // Detected: redundant Default flags, report Default-flagged count over total track count per
+        // type so the reason is visible (1/1 = lone track, 2/4 = multiple defaults)
         Log.Warning(
-            "Redundant Default flags detected : Video: {Video}, Audio: {Audio}, Subtitle: {Subtitle} : {FileName}",
+            "Redundant Default flags detected : Video: {VideoDefault}/{VideoTotal}, Audio: {AudioDefault}/{AudioTotal}, Subtitle: {SubtitleDefault}/{SubtitleTotal} : {FileName}",
             MkvMergeProps.Video.Count(item => item.Flags.HasFlag(TrackProps.FlagsType.Default)),
+            MkvMergeProps.Video.Count,
             MkvMergeProps.Audio.Count(item => item.Flags.HasFlag(TrackProps.FlagsType.Default)),
+            MkvMergeProps.Audio.Count,
             MkvMergeProps.Subtitle.Count(item => item.Flags.HasFlag(TrackProps.FlagsType.Default)),
+            MkvMergeProps.Subtitle.Count,
             FileInfo.Name
         );
 


### PR DESCRIPTION
## Summary

The `Redundant Default flags detected` warning (added in #793) reported only the count of `Default`-flagged tracks per type (`Video: 1, Audio: 1, Subtitle: 0`), so it wasn't possible to tell *why* a track was flagged. Report the flagged count over the total track count per type instead:

`Redundant Default flags detected : Video: 1/1, Audio: 1/1, Subtitle: 0/2`

Now the reason is visible:
- `1/1` — a lone track (a single track of a type needs no `Default` flag)
- `2/4` — multiple defaults (keep the preferred, clear the rest)

Message-only change; full suite green (162).