### PR TITLE
Add the global editorconfig CRLF default

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,7 @@ root = true
 # Defaults
 [*]
 charset = utf-8
+end_of_line = crlf
 indent_size = 4
 indent_style = space
 insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -45,6 +45,10 @@ end_of_line = crlf
 [*.sh]
 end_of_line = lf
 
+# Husky git hook is an extensionless shell script - LF like other scripts (matches the .gitattributes pin)
+[.husky/pre-commit]
+end_of_line = lf
+
 # Dockerfiles - CRLF breaks RUN heredocs and line continuations
 [{Dockerfile,*.Dockerfile}]
 end_of_line = lf


### PR DESCRIPTION
Adds `end_of_line = crlf` to the `.editorconfig` `[*]` block so every file type has a defined ending (matching the fleet template) instead of the per-extension-only form. Per-type CRLF rules and `.gitattributes` LF pins unchanged.

Resolves the recurring line-ending drift from the ProjectTemplate audit (`reports/plexcleaner/audit.md`), via the audit convergence pattern (`AUDIT.md` section 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)