### PR TITLE
Build the multi-arch image only on main, amd64 elsewhere

### DIFF
--- a/.github/workflows/build-docker-task.yml
+++ b/.github/workflows/build-docker-task.yml
@@ -1,6 +1,6 @@
 name: Build Docker image task
 
-# Builds the multi-arch image (linux/amd64,arm64) and, on a main publish, pushes it plus the Docker Hub overview.
+# Builds the image (multi-arch on main, amd64 on develop/smoke) and, on a main publish, pushes it plus the Docker Hub overview.
 # Branch drives config and tags: main => Release/`latest`, else Debug/`develop`, plus the `:SemVer2` tag. Smoke builds
 # amd64 only and never pushes; registry buildcache is branch-scoped. The orchestrator passes `branch` explicitly
 # (the publisher builds one branch per run - the trigger ref - and smoke passes github.ref_name).
@@ -46,6 +46,9 @@ jobs:
   build-docker:
     name: Build Docker image job
     runs-on: ubuntu-latest
+    env:
+      # Multi-arch (amd64+arm64) only on a full main publish; smoke and develop build amd64 only.
+      PLATFORMS: ${{ (!inputs.smoke && inputs.branch == 'main') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
     steps:
 
@@ -54,17 +57,17 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      # QEMU only emulates arm64; smoke is amd64-only, so skip it to save setup cost.
+      # arm64 is non-native on the amd64 runner, so install its QEMU emulator only when the build includes it.
       - name: Setup QEMU step
-        if: ${{ !inputs.smoke }}
+        if: ${{ contains(env.PLATFORMS, 'arm64') }}
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: arm64
 
       - name: Setup Buildx step
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
-          platforms: ${{ inputs.smoke && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ env.PLATFORMS }}
 
       # Always login (even on smoke) for higher pull/cache-read rate limits; the credentials are in both the
       # Actions and Dependabot secret stores so a Dependabot push CI run can log in too. Forks cannot push here.
@@ -83,7 +86,7 @@ jobs:
           tags: |
             docker.io/ptr727/plexcleaner:${{ inputs.branch == 'main' && 'latest' || 'develop' }}
             docker.io/ptr727/plexcleaner:${{ inputs.semver2 }}
-          platforms: ${{ inputs.smoke && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ env.PLATFORMS }}
           # Read both branches' caches (near-identical layers), write only this branch's tag and only when pushing.
           # mode=max caches the builder publish; ignore-error keeps a cache hiccup from failing a publish.
           cache-from: |


### PR DESCRIPTION
Adopt the fleet #248 branch-conditional Docker platforms. The Docker build is ~99% of Actions minutes, and arm64 is emulated (slow) on the amd64 runner, so build multi-arch (`linux/amd64,linux/arm64`) only on a full `main` publish; smoke and `develop` build `linux/amd64` only. A job-level `env.PLATFORMS` drives buildx + build-push, and QEMU (arm64 emulator) is installed only when `arm64` is in the set. Mirrors the already-merged ESPHome-NonRoot form. actionlint + editorconfig-checker clean; workflow stays LF.