### PR TITLE
Log full file paths and surface interlaced detection source

### DIFF
--- a/PlexCleaner/ProcessDriver.cs
+++ b/PlexCleaner/ProcessDriver.cs
@@ -263,7 +263,7 @@ public static class ProcessDriver
                 {
                     Log.Warning(
                         "Skipping media with errors : {FileName}",
-                        processFile.FileInfo.Name
+                        processFile.FileInfo.FullName
                     );
                     return false;
                 }
@@ -376,7 +376,7 @@ public static class ProcessDriver
                 // Skip further validation if any errors
                 if (mediaInfoProps.HasErrors || ffProbeProps.HasErrors || mkvMergeProps.HasErrors)
                 {
-                    Log.Warning("Media metadata has errors : {File}", fileInfo.Name);
+                    Log.Warning("Media metadata has errors : {FileName}", fileInfo.FullName);
                     return true;
                 }
 
@@ -395,7 +395,7 @@ public static class ProcessDriver
                     || mkvMergeProps.Subtitle.Count != mediaInfoProps.Subtitle.Count
                 )
                 {
-                    Log.Warning("Tool track count discrepancy : {File}", fileInfo.Name);
+                    Log.Warning("Tool track count discrepancy : {FileName}", fileInfo.FullName);
                 }
 
                 // If Matroska container then MkvMerge and MediaInfo track Uid's should match
@@ -409,7 +409,10 @@ public static class ProcessDriver
                         )
                     )
                     {
-                        Log.Warning("MkvMerge video track Uid mismatch : {File}", fileInfo.Name);
+                        Log.Warning(
+                            "MkvMerge video track Uid mismatch : {FileName}",
+                            fileInfo.FullName
+                        );
                     }
                     if (
                         mkvMergeProps.Audio.Any(mkvItem =>
@@ -419,7 +422,10 @@ public static class ProcessDriver
                         )
                     )
                     {
-                        Log.Warning("MkvMerge audio track Uid mismatch : {File}", fileInfo.Name);
+                        Log.Warning(
+                            "MkvMerge audio track Uid mismatch : {FileName}",
+                            fileInfo.FullName
+                        );
                     }
                     if (
                         mkvMergeProps.Subtitle.Any(mkvItem =>
@@ -429,7 +435,10 @@ public static class ProcessDriver
                         )
                     )
                     {
-                        Log.Warning("MkvMerge subtitle track Uid mismatch : {File}", fileInfo.Name);
+                        Log.Warning(
+                            "MkvMerge subtitle track Uid mismatch : {FileName}",
+                            fileInfo.FullName
+                        );
                     }
                 }
 

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -56,7 +56,7 @@ public class ProcessFile
         // Media file does not exists, delete this sidecar file
         Log.Information(
             "Deleting sidecar file with no matching MKV file : {FileName}",
-            FileInfo.Name
+            FileInfo.FullName
         );
 
         // Delete the file
@@ -79,12 +79,12 @@ public class ProcessFile
         // Only delete if the option is enabled else just skip
         if (!Program.Config.ProcessOptions.DeleteUnwantedExtensions)
         {
-            Log.Warning("Skipping non-MKV file : {FileName}", FileInfo.Name);
+            Log.Warning("Skipping non-MKV file : {FileName}", FileInfo.FullName);
             return false;
         }
 
         // Non-MKV file, delete
-        Log.Warning("Deleting non-MKV file : {FileName}", FileInfo.Name);
+        Log.Warning("Deleting non-MKV file : {FileName}", FileInfo.FullName);
 
         // Delete the file
         File.Delete(FileInfo.FullName);
@@ -105,7 +105,7 @@ public class ProcessFile
         }
 
         // Make the extension lowercase
-        Log.Information("Making file extension lowercase : {FileName}", FileInfo.Name);
+        Log.Information("Making file extension lowercase : {FileName}", FileInfo.FullName);
 
         // Rename the file
         // Windows is case insensitive, so we need to rename in two steps
@@ -146,11 +146,11 @@ public class ProcessFile
         Log.Warning(
             "ReMux extension detected : Extension: {Extension} : {FileName}",
             FileInfo.Extension,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
         // ReMux the file
-        Log.Information("Remux file matched by extension : {FileName}", FileInfo.Name);
+        Log.Information("Remux file matched by extension : {FileName}", FileInfo.FullName);
 
         // ReMux the file, use the new filename
         if (!Convert.ReMuxToMkv(FileInfo.FullName, out string outputName))
@@ -182,7 +182,7 @@ public class ProcessFile
             Log.Error(
                 "MKV file is not in Matroska format, ReMux option not enabled : Container: {Container} : {FileName}",
                 MkvMergeProps.Container,
-                FileInfo.Name
+                FileInfo.FullName
             );
             return false;
         }
@@ -191,7 +191,7 @@ public class ProcessFile
         Log.Information(
             "ReMux {Container} to Matroska : {FileName}",
             MkvMergeProps.Container,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
         // ReMux the file, use the new filename
@@ -339,10 +339,10 @@ public class ProcessFile
         Log.Warning(
             "Invalid language tags detected : Tracks: {Tracks} : {FileName}",
             selectMediaProps.Selected.Count,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
-        Log.Information("Setting invalid language tags : {FileName}", FileInfo.Name);
+        Log.Information("Setting invalid language tags : {FileName}", FileInfo.FullName);
         selectMediaProps.WriteLine("Invalid", "Keep");
 
         // Recover from the valid tag, else undefined
@@ -384,7 +384,7 @@ public class ProcessFile
         Log.Error(
             "Verification failed, marking as VerifyFailed : {Operation} : {FileName}",
             operation,
-            FileInfo.Name
+            FileInfo.FullName
         );
         _sidecarFile.State |= SidecarFile.StatesType.VerifyFailed;
         _sidecarFile.State &= ~SidecarFile.StatesType.Verified;
@@ -445,11 +445,11 @@ public class ProcessFile
             removeErrors,
             remuxErrors,
             setLanguageErrors,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
         // ReMux the file
-        Log.Information("Remux to repair metadata errors : {FileName}", FileInfo.Name);
+        Log.Information("Remux to repair metadata errors : {FileName}", FileInfo.FullName);
         selectMediaProps.WriteLine("Keep", "Remove");
 
         // Conditional with tracks or all tracks
@@ -500,7 +500,7 @@ public class ProcessFile
             Log.Error(
                 "Multiple video tracks not supported, ReMux option not enabled : Video: {TrackCount} : {FileName}",
                 MkvMergeProps.Video.Count,
-                FileInfo.Name
+                FileInfo.FullName
             );
             return false;
         }
@@ -521,11 +521,11 @@ public class ProcessFile
         Log.Warning(
             "Extra video tracks detected : Video: {Video} : {FileName}",
             MkvMergeProps.Video.Count,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
         // ReMux the file
-        Log.Information("Remux to remove extra video tracks : {FileName}", FileInfo.Name);
+        Log.Information("Remux to remove extra video tracks : {FileName}", FileInfo.FullName);
         selectMediaProps.WriteLine("Keep", "Remove");
         if (!Convert.ReMuxToMkv(FileInfo.FullName, selectMediaProps, out string outputName))
         {
@@ -561,7 +561,7 @@ public class ProcessFile
             MkvMergeProps.Video.Count(item => item.State == TrackProps.StateType.SetFlags)
                 + MkvMergeProps.Audio.Count(item => item.State == TrackProps.StateType.SetFlags)
                 + MkvMergeProps.Subtitle.Count(item => item.State == TrackProps.StateType.SetFlags),
-            FileInfo.Name
+            FileInfo.FullName
         );
 
         // Already flagged?
@@ -569,12 +569,12 @@ public class ProcessFile
         {
             Log.Warning(
                 "Metadata errors re-detected after setting flags : {FileName}",
-                FileInfo.Name
+                FileInfo.FullName
             );
         }
 
         // Setting flags
-        Log.Information("Setting track flags on media file : {FileName}", FileInfo.Name);
+        Log.Information("Setting track flags on media file : {FileName}", FileInfo.FullName);
 
         // Set flags using MkvMergeInfo
         Debug.Assert(
@@ -619,17 +619,17 @@ public class ProcessFile
             MkvMergeProps.Audio.Count,
             MkvMergeProps.Subtitle.Count(item => item.Flags.HasFlag(TrackProps.FlagsType.Default)),
             MkvMergeProps.Subtitle.Count,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
         // Re-detected after a previous clearing pass, e.g. reintroduced by re-encoding
         if (_sidecarFile.State.HasFlag(SidecarFile.StatesType.ClearedDefaultFlags))
         {
-            Log.Warning("Default flags re-detected after clearing : {FileName}", FileInfo.Name);
+            Log.Warning("Default flags re-detected after clearing : {FileName}", FileInfo.FullName);
         }
 
         // Clear the redundant Default flags
-        Log.Information("Clearing redundant Default flags : {FileName}", FileInfo.Name);
+        Log.Information("Clearing redundant Default flags : {FileName}", FileInfo.FullName);
         clearList.ForEach(item => item.WriteLine("Default"));
         if (!Tools.MkvPropEdit.ClearDefaultFlags(FileInfo.FullName, clearList))
         {
@@ -711,7 +711,7 @@ public class ProcessFile
             return true;
         }
 
-        Log.Warning("Matroska seek index unusable, {Issue} : {FileName}", issue, FileInfo.Name);
+        Log.Warning("Matroska seek index unusable, {Issue} : {FileName}", issue, FileInfo.FullName);
 
         // Can we repair
         if (!Program.Config.VerifyOptions.AutoRepair || !Program.Config.ProcessOptions.ReMux)
@@ -720,7 +720,7 @@ public class ProcessFile
         }
 
         // Remux to rewrite the container structure
-        Log.Information("Remux to repair Matroska structure : {FileName}", FileInfo.Name);
+        Log.Information("Remux to repair Matroska structure : {FileName}", FileInfo.FullName);
         if (!Convert.ReMuxToMkv(FileInfo.FullName, out string outputName))
         {
             // Error
@@ -772,17 +772,23 @@ public class ProcessFile
         }
 
         // Detected: tags present
-        Log.Warning("Tags detected : {FileName}", FileInfo.Name);
+        Log.Warning(
+            "Tags detected : MkvMerge: {MkvMerge}, FfProbe: {FfProbe}, MediaInfo: {MediaInfo} : {FileName}",
+            MkvMergeProps.AnyTags,
+            FfProbeProps.AnyTags,
+            MediaInfoProps.AnyTags,
+            FileInfo.FullName
+        );
 
         // Already cleared?
         // Tags can re-appear after running FfMpeg or HandBrake
         if (_sidecarFile.State.HasFlag(SidecarFile.StatesType.ClearedTags))
         {
-            Log.Warning("Tags re-detected after clearing : {FileName}", FileInfo.Name);
+            Log.Warning("Tags re-detected after clearing : {FileName}", FileInfo.FullName);
         }
 
         // Remove tags
-        Log.Information("Clearing all tags from media file : {FileName}", FileInfo.Name);
+        Log.Information("Clearing all tags from media file : {FileName}", FileInfo.FullName);
 
         // Delete the tags
         if (!Tools.MkvPropEdit.ClearTags(FileInfo.FullName, MkvMergeProps))
@@ -810,17 +816,17 @@ public class ProcessFile
         Log.Warning(
             "Attachments detected : Attachments: {Attachments} : {FileName}",
             MkvMergeProps.Attachments,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
         // Already removed?
         if (_sidecarFile.State.HasFlag(SidecarFile.StatesType.RemovedAttachments))
         {
-            Log.Warning("Attachments re-detected after clearing : {FileName}", FileInfo.Name);
+            Log.Warning("Attachments re-detected after clearing : {FileName}", FileInfo.FullName);
         }
 
         // Remove attachments
-        Log.Information("Clearing attachments from media file : {FileName}", FileInfo.Name);
+        Log.Information("Clearing attachments from media file : {FileName}", FileInfo.FullName);
 
         // Delete the attachments
         if (!Tools.MkvPropEdit.ClearAttachments(FileInfo.FullName, MkvMergeProps))
@@ -854,7 +860,7 @@ public class ProcessFile
             // Error, cover art interferes with processing and must be removed, enable ReMux option
             Log.Error(
                 "Cover Art must be removed, ReMux option not enabled : {FileName}",
-                FileInfo.Name
+                FileInfo.FullName
             );
             return false;
         }
@@ -931,12 +937,16 @@ public class ProcessFile
         }
 
         // Detected: cover art present
-        Log.Warning("Cover Art detected : {FileName}", FileInfo.Name);
+        Log.Warning(
+            "Cover Art detected : Format: {Format} : {FileName}",
+            MkvMergeProps.Video.First(item => item.CoverArt).Format,
+            FileInfo.FullName
+        );
 
         // Already removed?
         if (_sidecarFile.State.HasFlag(SidecarFile.StatesType.RemovedCoverArt))
         {
-            Log.Warning("Cover Art re-detected after removing : {FileName}", FileInfo.Name);
+            Log.Warning("Cover Art re-detected after removing : {FileName}", FileInfo.FullName);
         }
 
         // Select all tracks with cover art
@@ -951,7 +961,7 @@ public class ProcessFile
         Debug.Assert(selectMediaProps.Selected.Count > 0);
         selectMediaProps.SetState(TrackProps.StateType.Keep, TrackProps.StateType.Remove);
 
-        Log.Information("Removing Cover Art from media file : {FileName}", FileInfo.Name);
+        Log.Information("Removing Cover Art from media file : {FileName}", FileInfo.FullName);
         selectMediaProps.WriteLine("Keep", "Remove");
 
         // ReMux and only keep the selected tracks
@@ -991,13 +1001,13 @@ public class ProcessFile
         Log.Warning(
             "Unknown language tracks detected : Tracks: {Tracks} : {FileName}",
             selectMediaProps.Selected.Count,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
         Log.Information(
             "Setting unknown language tracks to {DefaultLanguage} : {FileName}",
             Program.Config.ProcessOptions.DefaultLanguage,
-            FileInfo.Name
+            FileInfo.FullName
         );
         selectMediaProps.WriteLine("Unknown", "Known");
 
@@ -1044,10 +1054,10 @@ public class ProcessFile
         Log.Warning(
             "Unwanted language tracks detected : Tracks: {Tracks} : {FileName}",
             selectMediaProps.NotSelected.Count,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
-        Log.Information("Removing unwanted language tracks : {FileName}", FileInfo.Name);
+        Log.Information("Removing unwanted language tracks : {FileName}", FileInfo.FullName);
         selectMediaProps.WriteLine("Keep", "Remove");
 
         // ReMux and only keep the selected tracks
@@ -1088,10 +1098,10 @@ public class ProcessFile
         Log.Warning(
             "Duplicate tracks detected : Tracks: {Tracks} : {FileName}",
             selectMediaProps.NotSelected.Count,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
-        Log.Information("Removing duplicate tracks : {FileName}", FileInfo.Name);
+        Log.Information("Removing duplicate tracks : {FileName}", FileInfo.FullName);
         selectMediaProps.WriteLine("Keep", "Remove");
 
         // ReMux and only keep the specified tracks
@@ -1107,26 +1117,31 @@ public class ProcessFile
         return Refresh(outputName);
     }
 
-    private bool FindInterlacedTracks(bool conditional, out VideoProps? videoProps)
+    private bool FindInterlacedTracks(
+        bool conditional,
+        out VideoProps? videoProps,
+        out FfMpegIdetInfo? idetInfo
+    )
     {
         // Return false on error
-        // Set videoProps if interlaced
+        // Set videoProps if interlaced, idetInfo is set when detected by the idet scan (null for a metadata flag)
 
         // Any video tracks
         videoProps = null;
+        idetInfo = null;
         if (FfProbeProps.Video.Count == 0)
         {
             // No video tracks
             return true;
         }
 
-        // Are any interlaced attributes set
+        // Are any interlaced metadata flags set
         videoProps ??= FfProbeProps.Video.Find(item => item.Interlaced);
         videoProps ??= MediaInfoProps.Video.Find(item => item.Interlaced);
         videoProps ??= MkvMergeProps.Video.Find(item => item.Interlaced);
         if (videoProps != null)
         {
-            // Interlaced attribute set
+            // Interlaced metadata flag set
             return true;
         }
 
@@ -1150,8 +1165,8 @@ public class ProcessFile
             return true;
         }
 
-        // Count the frame types using the idet filter, expensive
-        if (!GetIdetInfo(out FfMpegIdetInfo? idetInfo) || idetInfo == null)
+        // Count the frame types using the idet filter
+        if (!GetIdetInfo(out idetInfo) || idetInfo == null)
         {
             // Error
             return false;
@@ -1160,20 +1175,14 @@ public class ProcessFile
         // Idet result
         if (!idetInfo.IsInterlaced())
         {
-            // Not interlaced
+            // Not interlaced, clear the idet info so the caller does not treat it as a detection
+            idetInfo = null;
             return true;
         }
-
-        // Idet said yes but metadata said no
-        Log.Warning(
-            "Idet reported interlaced, metadata reported not interlaced : {FileName}",
-            FileInfo.Name
-        );
 
         // Use the first video track from FfProbe
         videoProps = FfProbeProps.Video.First();
         videoProps.Interlaced = true;
-
         return true;
     }
 
@@ -1216,7 +1225,7 @@ public class ProcessFile
 
         // Get packet info using ccsub filter
         bool packetsFound = false;
-        Log.Information("Finding Closed Captions in video stream : {FileName}", FileInfo.Name);
+        Log.Information("Finding Closed Captions in video stream : {FileName}", FileInfo.FullName);
         if (
             !Tools.FfProbe.GetSubCcPackets(
                 FileInfo.FullName,
@@ -1230,7 +1239,10 @@ public class ProcessFile
         )
         {
             // Error
-            Log.Error("Failed to find Closed Captions in video stream : {FileName}", FileInfo.Name);
+            Log.Error(
+                "Failed to find Closed Captions in video stream : {FileName}",
+                FileInfo.FullName
+            );
             return false;
         }
 
@@ -1254,7 +1266,13 @@ public class ProcessFile
         }
 
         // Do we have any interlaced video
-        if (!FindInterlacedTracks(conditional, out VideoProps? videoProps))
+        if (
+            !FindInterlacedTracks(
+                conditional,
+                out VideoProps? videoProps,
+                out FfMpegIdetInfo? idetInfo
+            )
+        )
         {
             // Error
             return false;
@@ -1265,20 +1283,38 @@ public class ProcessFile
             return true;
         }
 
-        // Detected: interlaced video
-        Log.Warning(
-            "Interlaced video detected : Format: {Format} : {FileName}",
-            videoProps.Format,
-            FileInfo.Name
-        );
+        // Detected: interlaced video, idetInfo is set when the idet scan detected it, else a metadata flag
+        if (idetInfo != null)
+        {
+            FfMpegIdetInfo.Frames multiFrame = idetInfo.MultiFrame;
+            _ = idetInfo.IsInterlaced(out double percentage);
+            Log.Warning(
+                "Interlaced video detected : Format: {Format}, Detected by: Idet, MultiFrame: {Percentage:F2}% (TFF: {TFF}, BFF: {BFF}, Progressive: {Progressive}, Undetermined: {Undetermined}) : {FileName}",
+                videoProps.Format,
+                percentage,
+                multiFrame.Tff,
+                multiFrame.Bff,
+                multiFrame.Progressive,
+                multiFrame.Undetermined,
+                FileInfo.FullName
+            );
+        }
+        else
+        {
+            Log.Warning(
+                "Interlaced video detected : Format: {Format}, Detected by: Metadata flag : {FileName}",
+                videoProps.Format,
+                FileInfo.FullName
+            );
+        }
 
         // Already deinterlaced?
         if (State.HasFlag(SidecarFile.StatesType.DeInterlaced))
         {
-            Log.Warning("Deinterlacing already deinterlaced media : {FileName}", FileInfo.Name);
+            Log.Warning("Deinterlacing already deinterlaced media : {FileName}", FileInfo.FullName);
         }
 
-        Log.Information("Deinterlacing interlaced media : {FileName}", FileInfo.Name);
+        Log.Information("Deinterlacing interlaced media : {FileName}", FileInfo.FullName);
         videoProps.State = TrackProps.StateType.DeInterlace;
         videoProps.WriteLine("Interlaced");
 
@@ -1301,7 +1337,7 @@ public class ProcessFile
             )
         )
         {
-            Log.Error("Failed to deinterlace interlaced media : {FileName}", FileInfo.Name);
+            Log.Error("Failed to deinterlace interlaced media : {FileName}", FileInfo.FullName);
             Log.Error("{Error}", error);
             File.Delete(deintName);
             return false;
@@ -1315,10 +1351,10 @@ public class ProcessFile
         if (MkvMergeProps.Subtitle.Count == 0)
         {
             // No subtitles, just remux all content
-            Log.Information("Remuxing deinterlaced media : {FileName}", FileInfo.Name);
+            Log.Information("Remuxing deinterlaced media : {FileName}", FileInfo.FullName);
             if (!Tools.MkvMerge.ReMuxToMkv(deintName, remuxName, out error))
             {
-                Log.Error("Failed to remux deinterlaced media : {FileName}", FileInfo.Name);
+                Log.Error("Failed to remux deinterlaced media : {FileName}", FileInfo.FullName);
                 Log.Error("{Error}", error);
                 File.Delete(deintName);
                 File.Delete(remuxName);
@@ -1328,11 +1364,11 @@ public class ProcessFile
         else
         {
             // Merge the deinterlaced file with the subtitles from the original file
-            MediaProps subtitleProps = new(MediaTool.ToolType.MkvMerge, FileInfo.Name);
+            MediaProps subtitleProps = new(MediaTool.ToolType.MkvMerge, FileInfo.FullName);
             subtitleProps.Subtitle.AddRange(MkvMergeProps.Subtitle);
             Log.Information(
                 "Remuxing subtitles and deinterlaced media : {FileName}",
-                FileInfo.Name
+                FileInfo.FullName
             );
             if (
                 !Tools.MkvMerge.MergeToMkv(
@@ -1346,7 +1382,7 @@ public class ProcessFile
             {
                 Log.Error(
                     "Failed to remux subtitles and deinterlaced media : {FileName}",
-                    FileInfo.Name
+                    FileInfo.FullName
                 );
                 Log.Error("{Error}", error);
                 File.Delete(deintName);
@@ -1398,7 +1434,7 @@ public class ProcessFile
         {
             Log.Error(
                 "MkvMerge and HandBrake track metadata does not match : {FileName}",
-                FileInfo.Name
+                FileInfo.FullName
             );
             Debug.Assert(false);
             return false;
@@ -1430,16 +1466,22 @@ public class ProcessFile
         Log.Warning(
             "Closed Captions detected : Format: {Format} : {FileName}",
             videoProps.Format,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
         // Already removed?
         if (_sidecarFile.State.HasFlag(SidecarFile.StatesType.ClearedCaptions))
         {
-            Log.Warning("Closed Captions re-detected after removing : {FileName}", FileInfo.Name);
+            Log.Warning(
+                "Closed Captions re-detected after removing : {FileName}",
+                FileInfo.FullName
+            );
         }
 
-        Log.Information("Removing Closed Captions from video stream : {FileName}", FileInfo.Name);
+        Log.Information(
+            "Removing Closed Captions from video stream : {FileName}",
+            FileInfo.FullName
+        );
         videoProps.WriteLine("Closed Captions");
 
         // Get SEI NAL unit based on video format
@@ -1450,7 +1492,7 @@ public class ProcessFile
             Log.Error(
                 "Unsupported video format for Closed Captions removal : Format: {Format} : {FileName}",
                 videoProps.Format,
-                FileInfo.Name
+                FileInfo.FullName
             );
             return false;
         }
@@ -1470,7 +1512,7 @@ public class ProcessFile
             Log.Error(
                 "Removing Closed Captions may remove HDR10+ information : {Format} : {FileName}",
                 mediaInfoVideo.FormatHdr,
-                FileInfo.Name
+                FileInfo.FullName
             );
             return false;
         }
@@ -1480,11 +1522,14 @@ public class ProcessFile
         Debug.Assert(FileInfo.FullName != tempName);
 
         // Remove Closed Captions
-        Log.Information("Removing closed captions using FfMpeg : {FileName}", FileInfo.Name);
+        Log.Information("Removing closed captions using FfMpeg : {FileName}", FileInfo.FullName);
         if (!Tools.FfMpeg.RemoveNalUnits(FileInfo.FullName, nalUnit, tempName, out string error))
         {
             // Error
-            Log.Error("Failed to remove closed captions using FfMpeg : {FileName}", FileInfo.Name);
+            Log.Error(
+                "Failed to remove closed captions using FfMpeg : {FileName}",
+                FileInfo.FullName
+            );
             Log.Error("{Error}", error);
             File.Delete(tempName);
             return false;
@@ -1523,10 +1568,10 @@ public class ProcessFile
         Log.Warning(
             "Subtitles detected : Subtitle: {Subtitle} : {FileName}",
             MkvMergeProps.Subtitle.Count,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
-        Log.Information("Removing subtitles : {FileName}", FileInfo.Name);
+        Log.Information("Removing subtitles : {FileName}", FileInfo.FullName);
         MkvMergeProps.Subtitle.ForEach(item => item.WriteLine("Subtitles"));
 
         // Create a temp output filename
@@ -1537,7 +1582,7 @@ public class ProcessFile
         if (!Tools.MkvMerge.RemoveSubtitles(FileInfo.FullName, tempName, out string error))
         {
             // Error
-            Log.Error("Failed to remove subtitles : {FileName}", FileInfo.Name);
+            Log.Error("Failed to remove subtitles : {FileName}", FileInfo.FullName);
             Log.Error("{Error}", error);
             File.Delete(tempName);
             return false;
@@ -1575,16 +1620,16 @@ public class ProcessFile
         Log.Warning(
             "Tracks requiring re-encode detected : Tracks: {Tracks} : {FileName}",
             selectMediaProps.Selected.Count,
-            FileInfo.Name
+            FileInfo.FullName
         );
 
         // Already reencoded?
         if (State.HasFlag(SidecarFile.StatesType.ReEncoded))
         {
-            Log.Warning("Reencoding already reencoded media : {FileName}", FileInfo.Name);
+            Log.Warning("Reencoding already reencoded media : {FileName}", FileInfo.FullName);
         }
 
-        Log.Information("Reencoding required tracks : {FileName}", FileInfo.Name);
+        Log.Information("Reencoding required tracks : {FileName}", FileInfo.FullName);
         selectMediaProps.WriteLine("ReEncode", "Passthrough");
 
         // ReEncode selected tracks
@@ -1629,7 +1674,7 @@ public class ProcessFile
         {
             Log.Error(
                 "MkvMerge and FfMpeg track metadata does not match : {FileName}",
-                FileInfo.Name
+                FileInfo.FullName
             );
             Debug.Assert(false);
             return false;
@@ -1644,7 +1689,7 @@ public class ProcessFile
         // Tooling supports one and only one video track
         if (MkvMergeProps.Video.Count == 0)
         {
-            Log.Error("File missing video track : {FileName}", FileInfo.Name);
+            Log.Error("File missing video track : {FileName}", FileInfo.FullName);
             MkvMergeProps.WriteLine("Unsupported");
 
             // Error
@@ -1655,7 +1700,7 @@ public class ProcessFile
             Log.Error(
                 "File has more than one video track : Video: {Video} : {FileName}",
                 MkvMergeProps.Video.Count,
-                FileInfo.Name
+                FileInfo.FullName
             );
             MkvMergeProps.WriteLine("Unsupported");
 
@@ -1666,7 +1711,7 @@ public class ProcessFile
         // Warn if audio track is missing
         if (MkvMergeProps.Audio.Count == 0)
         {
-            Log.Warning("File missing audio : {FileName}", FileInfo.Name);
+            Log.Warning("File missing audio : {FileName}", FileInfo.FullName);
             MkvMergeProps.WriteLine("Missing");
 
             // Warning only
@@ -1729,7 +1774,7 @@ public class ProcessFile
     public static bool VerifyMediaStreams(FileInfo fileInfo)
     {
         // Verify
-        Log.Information("Verifying media streams : {FileName}", fileInfo.Name);
+        Log.Information("Verifying media streams : {FileName}", fileInfo.FullName);
         if (!Tools.FfMpeg.VerifyMedia(fileInfo.FullName, out string error))
         {
             // Cancel requested
@@ -1739,7 +1784,7 @@ public class ProcessFile
             }
 
             // Failed stream validation
-            Log.Error("Failed to verify media streams : {FileName}", fileInfo.Name);
+            Log.Error("Failed to verify media streams : {FileName}", fileInfo.FullName);
             Log.Error("{Error}", error);
 
             // Caller should update the state
@@ -1881,11 +1926,11 @@ public class ProcessFile
         // https://en.wikipedia.org/wiki/YIFY
 
         // Calculate bitrate
-        Log.Information("Calculating bitrate info : {FileName}", FileInfo.Name);
+        Log.Information("Calculating bitrate info : {FileName}", FileInfo.FullName);
         if (!GetBitrateInfo(out BitrateInfo? bitrateInfo) || bitrateInfo == null)
         {
             // Error
-            Log.Error("Failed to calculate bitrate info : {FileName}", FileInfo.Name);
+            Log.Error("Failed to calculate bitrate info : {FileName}", FileInfo.FullName);
             return false;
         }
 
@@ -1899,7 +1944,7 @@ public class ProcessFile
                 "Maximum bitrate exceeded : {CombinedBitrate} > {MaximumBitrate} : {FileName}",
                 Bitrate.ToBitsPerSecond(bitrateInfo.CombinedBitrate.Maximum),
                 Bitrate.ToBitsPerSecond(Program.Config.VerifyOptions.MaximumBitrate / 8),
-                FileInfo.Name
+                FileInfo.FullName
             );
 
             // Caller must Refresh()
@@ -1915,7 +1960,7 @@ public class ProcessFile
                 "Audio bitrate exceeds Video bitrate : {AudioBitrate} > {VideoBitrate} : {FileName}",
                 Bitrate.ToBitsPerSecond(bitrateInfo.AudioBitrate.Average),
                 Bitrate.ToBitsPerSecond(bitrateInfo.VideoBitrate.Average),
-                FileInfo.Name
+                FileInfo.FullName
             );
 
             // Warning only
@@ -1990,7 +2035,7 @@ public class ProcessFile
                 "Video is not HDR10 compatible : {Hdr} not in {Hdr10}: {FileName}",
                 videoItem.FormatHdr,
                 Hdr10FormatList,
-                FileInfo.Name
+                FileInfo.FullName
             );
 
             // Warning only
@@ -2008,7 +2053,7 @@ public class ProcessFile
         // Trying again may not succeed unless the tools changed
         if (_sidecarFile.State.HasFlag(SidecarFile.StatesType.RepairFailed))
         {
-            Log.Warning("Repairing previously repaired media : {FileName}", FileInfo.Name);
+            Log.Warning("Repairing previously repaired media : {FileName}", FileInfo.FullName);
         }
 
         // TODO: Analyze the error output and conditionally repair only the audio or video track
@@ -2052,7 +2097,7 @@ public class ProcessFile
         // Convert using ffmpeg
         Log.Information(
             "Attempting media repair by reencoding using FfMpeg : {FileName}",
-            FileInfo.Name
+            FileInfo.FullName
         );
         if (!Tools.FfMpeg.ConvertToMkv(FileInfo.FullName, tempName, out string error))
         {
@@ -2066,13 +2111,13 @@ public class ProcessFile
             }
 
             // Failed
-            Log.Error("Failed to reencode using FfMpeg : {FileName}", FileInfo.Name);
+            Log.Error("Failed to reencode using FfMpeg : {FileName}", FileInfo.FullName);
             Log.Error("{Error}", error);
 
             // Try again using handbrake
             Log.Information(
                 "Attempting media repair by reencoding using HandBrake : {FileName}",
-                FileInfo.Name
+                FileInfo.FullName
             );
             if (!Tools.HandBrake.ConvertToMkv(FileInfo.FullName, tempName, true, false, out error))
             {
@@ -2086,7 +2131,7 @@ public class ProcessFile
                 }
 
                 // Failed
-                Log.Error("Failed to reencode using HandBrake : {FileName}", FileInfo.Name);
+                Log.Error("Failed to reencode using HandBrake : {FileName}", FileInfo.FullName);
                 Log.Error("{Error}", error);
 
                 // Caller will update state
@@ -2114,7 +2159,7 @@ public class ProcessFile
         File.Move(tempName, FileInfo.FullName, true);
 
         // Repair succeeded
-        Log.Information("Repair succeeded : {FileName}", FileInfo.Name);
+        Log.Information("Repair succeeded : {FileName}", FileInfo.FullName);
 
         // Caller will update state
         return true;
@@ -2218,7 +2263,7 @@ public class ProcessFile
         )
         {
             // Something is very wrong; bad logic, bad media, bad tools?
-            Log.Error("Tool track count discrepancy : {File}", FileInfo.Name);
+            Log.Error("Tool track count discrepancy : {FileName}", FileInfo.FullName);
             MediaInfoProps.WriteLine();
             MkvMergeProps.WriteLine();
             FfProbeProps.WriteLine();
@@ -2239,14 +2284,14 @@ public class ProcessFile
         // Get media info
         if (!Refresh(false))
         {
-            Log.Error("Failed to get media tool info : {FileName}", FileInfo.Name);
+            Log.Error("Failed to get media tool info : {FileName}", FileInfo.FullName);
             return false;
         }
 
         // Verify that all codecs and tracks are supported
         if (MediaInfoProps.Unsupported || FfProbeProps.Unsupported || MkvMergeProps.Unsupported)
         {
-            Log.Error("Unsupported media info : {FileName}", FileInfo.Name);
+            Log.Error("Unsupported media info : {FileName}", FileInfo.FullName);
             if (MediaInfoProps.Unsupported)
             {
                 MediaInfoProps.WriteLine("Unsupported");
@@ -2273,14 +2318,14 @@ public class ProcessFile
         // Get media info
         if (!Refresh(false))
         {
-            Log.Error("Failed to get media tool info : {FileName}", FileInfo.Name);
+            Log.Error("Failed to get media tool info : {FileName}", FileInfo.FullName);
             return false;
         }
 
         // Verify that all codecs and tracks are supported
         if (MediaInfoProps.Unsupported || FfProbeProps.Unsupported || MkvMergeProps.Unsupported)
         {
-            Log.Error("Unsupported media info : {FileName}", FileInfo.Name);
+            Log.Error("Unsupported media info : {FileName}", FileInfo.FullName);
             if (MediaInfoProps.Unsupported)
             {
                 MediaInfoProps.WriteLine("Unsupported");
@@ -2343,7 +2388,7 @@ public class ProcessFile
     private bool GetIdetInfo(out FfMpegIdetInfo? idetInfo)
     {
         // Count the frame types using the idet filter
-        Log.Information("Counting interlaced frames : {FileName}", FileInfo.Name);
+        Log.Information("Counting interlaced frames : {FileName}", FileInfo.FullName);
         if (
             !FfMpegIdetInfo.GetIdetInfo(FileInfo.FullName, out idetInfo, out string error)
             || idetInfo == null
@@ -2356,7 +2401,7 @@ public class ProcessFile
             }
 
             // Error
-            Log.Error("Failed to count interlaced frames : {FileName}", FileInfo.Name);
+            Log.Error("Failed to count interlaced frames : {FileName}", FileInfo.FullName);
             Log.Error("{Error}", error);
             return false;
         }
@@ -2425,7 +2470,7 @@ public class ProcessFile
                     "Audio reencoding requires video reencoding : Audio: {FormatA}, Video: {FormatV} : {FileName}",
                     selectMediaProps.Selected.Audio.Select(item => $"{item.Format}:{item.Codec}"),
                     reEncodeVideo.Select(item => $"{item.Format}:{item.Codec}:{item.Profile}"),
-                    FileInfo.Name
+                    FileInfo.FullName
                 );
             }
         }
@@ -2545,7 +2590,7 @@ public class ProcessFile
                 Language.GetLanguageList(MkvMergeProps.Video),
                 Program.Config.ProcessOptions.KeepLanguages,
                 videoProps.LanguageIetf,
-                FileInfo.Name
+                FileInfo.FullName
             );
         }
 
@@ -2560,7 +2605,7 @@ public class ProcessFile
                 Language.GetLanguageList(MkvMergeProps.Audio),
                 Program.Config.ProcessOptions.KeepLanguages,
                 audioProps.LanguageIetf,
-                FileInfo.Name
+                FileInfo.FullName
             );
         }
 
@@ -2571,7 +2616,7 @@ public class ProcessFile
                 "No subtitle track matching requested language : {Available} not in {Languages} : {FileName}",
                 Language.GetLanguageList(MkvMergeProps.Subtitle),
                 Program.Config.ProcessOptions.KeepLanguages,
-                FileInfo.Name
+                FileInfo.FullName
             );
         }
 

--- a/PlexCleaner/SidecarFile.cs
+++ b/PlexCleaner/SidecarFile.cs
@@ -98,7 +98,7 @@ public class SidecarFile
         Log.Information(
             "Sidecar created : State: {State} : {FileName}",
             State,
-            _sidecarFileInfo.Name
+            _sidecarFileInfo.FullName
         );
 
         return true;
@@ -138,7 +138,7 @@ public class SidecarFile
             current = false;
             Log.Warning(
                 "Sidecar out of sync with media file, clearing state : {FileName}",
-                _sidecarFileInfo.Name
+                _sidecarFileInfo.FullName
             );
             State = StatesType.FileModified;
         }
@@ -156,13 +156,17 @@ public class SidecarFile
             {
                 Log.Warning(
                     "Sidecar out of sync with tools, clearing Verified flag : {FileName}",
-                    _sidecarFileInfo.Name
+                    _sidecarFileInfo.FullName
                 );
                 State &= ~StatesType.Verified;
             }
         }
 
-        Log.Information("Sidecar read : State: {State} : {FileName}", State, _sidecarFileInfo.Name);
+        Log.Information(
+            "Sidecar read : State: {State} : {FileName}",
+            State,
+            _sidecarFileInfo.FullName
+        );
 
         return true;
     }
@@ -198,7 +202,7 @@ public class SidecarFile
         Log.Information(
             "Sidecar updated : State: {State} : {FileName}",
             State,
-            _sidecarFileInfo.Name
+            _sidecarFileInfo.FullName
         );
 
         return true;
@@ -262,7 +266,7 @@ public class SidecarFile
     {
         Debug.Assert(_sidecarJson != null);
 
-        Log.Information("Reading media info from sidecar : {FileName}", _sidecarFileInfo.Name);
+        Log.Information("Reading media info from sidecar : {FileName}", _sidecarFileInfo.FullName);
 
         // Decompress the tool data
         _mediaInfoJson = StringCompression.Decompress(_sidecarJson.MediaInfoData);
@@ -276,7 +280,7 @@ public class SidecarFile
             || string.IsNullOrEmpty(_ffProbeJson)
         )
         {
-            Log.Error("Media info tool data is missing : {FileName}", _sidecarFileInfo.Name);
+            Log.Error("Media info tool data is missing : {FileName}", _sidecarFileInfo.FullName);
             return false;
         }
 
@@ -284,22 +288,22 @@ public class SidecarFile
         if (
             !MediaInfo.Tool.GetMediaPropsFromJson(
                 _mediaInfoJson,
-                _mediaFileInfo.Name,
+                _mediaFileInfo.FullName,
                 out MediaProps mediaInfoProps
             )
             || !MkvMerge.Tool.GetMediaPropsFromJson(
                 _mkvMergeJson,
-                _mediaFileInfo.Name,
+                _mediaFileInfo.FullName,
                 out MediaProps mkvMergeProps
             )
             || !FfProbe.Tool.GetMediaPropsFromJson(
                 _ffProbeJson,
-                _mediaFileInfo.Name,
+                _mediaFileInfo.FullName,
                 out MediaProps ffProbeProps
             )
         )
         {
-            Log.Error("Failed to de-serialize tool data : {FileName}", _sidecarFileInfo.Name);
+            Log.Error("Failed to de-serialize tool data : {FileName}", _sidecarFileInfo.FullName);
             return false;
         }
 
@@ -335,7 +339,7 @@ public class SidecarFile
                     "Sidecar LastWriteTimeUtc out of sync with media file : {SidecarJsonMediaLastWriteTimeUtc} != {MediaFileLastWriteTimeUtc} : {FileName}",
                     _sidecarJson.MediaLastWriteTimeUtc,
                     _mediaFileInfo.LastWriteTimeUtc,
-                    _sidecarFileInfo.Name
+                    _sidecarFileInfo.FullName
                 );
             }
         }
@@ -350,7 +354,7 @@ public class SidecarFile
                     "Sidecar FileLength out of sync with media file : {SidecarJsonMediaLength} != {MediaFileLength} : {FileName}",
                     _sidecarJson.MediaLength,
                     _mediaFileInfo.Length,
-                    _sidecarFileInfo.Name
+                    _sidecarFileInfo.FullName
                 );
             }
         }
@@ -366,7 +370,7 @@ public class SidecarFile
                     "Sidecar SHA256 out of sync with media file : {SidecarJsonHash} != {MediaFileHash} : {FileName}",
                     _sidecarJson.MediaHash,
                     hash,
-                    _sidecarFileInfo.Name
+                    _sidecarFileInfo.FullName
                 );
             }
         }
@@ -398,7 +402,7 @@ public class SidecarFile
                     "Sidecar FfProbe tool version mismatch : {SidecarJsonFfProbeToolVersion} != {ToolsFfProbeInfoVersion} : {FileName}",
                     _sidecarJson.FfProbeToolVersion,
                     Tools.FfProbe.Info.Version,
-                    _sidecarFileInfo.Name
+                    _sidecarFileInfo.FullName
                 );
             }
         }
@@ -418,7 +422,7 @@ public class SidecarFile
                     "Sidecar MkvMerge tool version mismatch : {SidecarJsonMkvMergeToolVersion} != {ToolsMkvMergeInfoVersion} : {FileName}",
                     _sidecarJson.MkvMergeToolVersion,
                     Tools.MkvMerge.Info.Version,
-                    _sidecarFileInfo.Name
+                    _sidecarFileInfo.FullName
                 );
             }
         }
@@ -438,7 +442,7 @@ public class SidecarFile
                     "Sidecar MediaInfo tool version mismatch : {SidecarJsonMediaInfoToolVersion} != {ToolsMediaInfoVersion} : {FileName}",
                     _sidecarJson.MediaInfoToolVersion,
                     Tools.MediaInfo.Info.Version,
-                    _sidecarFileInfo.Name
+                    _sidecarFileInfo.FullName
                 );
             }
         }
@@ -455,7 +459,7 @@ public class SidecarFile
         }
         catch (Exception e) when (Log.Logger.LogAndHandle(e))
         {
-            Log.Error("Failed to read JSON from file : {FileName}", _sidecarFileInfo.Name);
+            Log.Error("Failed to read JSON from file : {FileName}", _sidecarFileInfo.FullName);
             return false;
         }
         Debug.Assert(_sidecarJson != null);
@@ -472,7 +476,7 @@ public class SidecarFile
         }
         catch (Exception e) when (Log.Logger.LogAndHandle(e))
         {
-            Log.Error("Failed to write JSON to file : {FileName}", _sidecarFileInfo.Name);
+            Log.Error("Failed to write JSON to file : {FileName}", _sidecarFileInfo.FullName);
             return false;
         }
         return true;
@@ -507,7 +511,7 @@ public class SidecarFile
 
     private bool GetToolInfo()
     {
-        Log.Information("Reading media info from tools : {FileName}", _mediaFileInfo.Name);
+        Log.Information("Reading media info from tools : {FileName}", _mediaFileInfo.FullName);
 
         // Read the tool data text
         if (
@@ -516,7 +520,7 @@ public class SidecarFile
             || !Tools.FfProbe.GetMediaPropsJson(_mediaFileInfo.FullName, out _ffProbeJson)
         )
         {
-            Log.Error("Failed to read media properties : {FileName}", _mediaFileInfo.Name);
+            Log.Error("Failed to read media properties : {FileName}", _mediaFileInfo.FullName);
             return false;
         }
 
@@ -524,22 +528,22 @@ public class SidecarFile
         if (
             !MediaInfo.Tool.GetMediaPropsFromJson(
                 _mediaInfoJson,
-                _mediaFileInfo.Name,
+                _mediaFileInfo.FullName,
                 out MediaProps mediaInfoProps
             )
             || !MkvMerge.Tool.GetMediaPropsFromJson(
                 _mkvMergeJson,
-                _mediaFileInfo.Name,
+                _mediaFileInfo.FullName,
                 out MediaProps mkvMergeProps
             )
             || !FfProbe.Tool.GetMediaPropsFromJson(
                 _ffProbeJson,
-                _mediaFileInfo.Name,
+                _mediaFileInfo.FullName,
                 out MediaProps ffProbeProps
             )
         )
         {
-            Log.Error("Failed to de-serialize tool data : {FileName}", _mediaFileInfo.Name);
+            Log.Error("Failed to de-serialize tool data : {FileName}", _mediaFileInfo.FullName);
             return false;
         }
 
@@ -578,7 +582,10 @@ public class SidecarFile
                 _ = fileStream.Seek(0, SeekOrigin.Begin);
                 if (fileStream.Read(hashBuffer, 0, hashSize) != _mediaFileInfo.Length)
                 {
-                    Log.Error("Error reading from media file : {FileName}", _mediaFileInfo.Name);
+                    Log.Error(
+                        "Error reading from media file : {FileName}",
+                        _mediaFileInfo.FullName
+                    );
                     return string.Empty;
                 }
             }
@@ -588,7 +595,10 @@ public class SidecarFile
                 _ = fileStream.Seek(0, SeekOrigin.Begin);
                 if (fileStream.Read(hashBuffer, 0, HashWindowLength) != HashWindowLength)
                 {
-                    Log.Error("Error reading from media file : {FileName}", _mediaFileInfo.Name);
+                    Log.Error(
+                        "Error reading from media file : {FileName}",
+                        _mediaFileInfo.FullName
+                    );
                     return string.Empty;
                 }
 
@@ -599,7 +609,10 @@ public class SidecarFile
                     != HashWindowLength
                 )
                 {
-                    Log.Error("Error reading from media file : {FileName}", _mediaFileInfo.Name);
+                    Log.Error(
+                        "Error reading from media file : {FileName}",
+                        _mediaFileInfo.FullName
+                    );
                     return string.Empty;
                 }
             }

--- a/PlexCleaner/VideoProps.cs
+++ b/PlexCleaner/VideoProps.cs
@@ -147,7 +147,7 @@ public class VideoProps(MediaProps mediaProps) : TrackProps(TrackType.Video, med
         if (CoverArt)
         {
             Log.Warning(
-                "{Parser} : {Type} : Cover art video track : Format: {Format}, Codec: {Codec} : {fileName}",
+                "{Parser} : {Type} : Cover art video track : Format: {Format}, Codec: {Codec} : {FileName}",
                 Parent.Parser,
                 Type,
                 Format,


### PR DESCRIPTION
## Why

Media log lines identified files by **base name only**, which is ambiguous when same-named files (e.g. 4K vs 1080p `Movie (2020).mkv`) live in different folders — you can't tell which one a warning refers to. Interlaced detections also didn't say, in one line, whether they came from a container metadata flag or the idet content scan.

## What

**Full file paths** in media logs — `ProcessFile`, `SidecarFile`, and `ProcessDriver` report lines now log `FullName`, including the per-track dumps (via `MediaProps` construction). The static verify log keeps logging the actual file it verifies (scope *or* temp), now at full path.

**Interlaced detection**
- `FindInterlacedTracks` is a pure predicate (no logging). It outs an `FfMpegIdetInfo?` that is non-null **only** when the idet scan detected interlacing (null for a metadata flag) — the object both signals the source and carries the evidence.
- `DeInterlace` logs one warning reporting how it was detected, and for idet extracts the MultiFrame detail from the out object:
  ```
  Interlaced video detected : Format: "h264", Detected by: Idet, MultiFrame: 58.30% (TFF: 5123, BFF: 12, Progressive: 3001, Undetermined: 40) : "/media/…/Movie.mkv"
  Interlaced video detected : Format: "h264", Detected by: Metadata flag : "/media/…/Movie.mkv"
  ```

**Log detail / consistency**
- `Tags detected` reports which tools see tags; `Cover Art detected` reports the format.
- Normalised the log placeholder to `{FileName}` everywhere (`{File}` ×6 and a stray `{fileName}` renamed) — placeholder-name only, rendered text unchanged.

## Notes

Logging/consistency change with no new unit-testable logic, so no test change. Build clean (0 warnings), csharpier + dotnet format clean, existing suite (162 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)