### PR TITLE
Encapsulate interlaced decision in a self-describing reason string

### DIFF
--- a/PlexCleaner/FfMpegIdetInfo.cs
+++ b/PlexCleaner/FfMpegIdetInfo.cs
@@ -60,11 +60,10 @@ public partial class FfMpegIdetInfo
     public Frames SingleFrame { get; set; } = new();
     public Frames MultiFrame { get; set; } = new();
 
-    public bool IsInterlaced() => IsInterlaced(out _);
+    // MultiFrame is idet's temporally aware and more reliable detector, SingleFrame is noisier
+    public bool IsInterlaced() => MultiFrame.IsInterlaced();
 
-    public bool IsInterlaced(out string reason) =>
-        // MultiFrame is idet's temporally aware and more reliable detector, SingleFrame is noisier
-        MultiFrame.IsInterlaced(out reason);
+    public bool IsInterlaced(out string reason) => MultiFrame.IsInterlaced(out reason);
 
     public static bool GetIdetInfo(string fileName, out FfMpegIdetInfo? idetInfo, out string error)
     {
@@ -160,27 +159,27 @@ public partial class FfMpegIdetInfo
         public int Determined => Interlaced + Progressive;
         public int Total => Tff + Bff + Progressive + Undetermined;
 
-        public bool IsInterlaced(out string reason)
+        public bool IsInterlaced() => Evaluate(buildReason: false, out _);
+
+        public bool IsInterlaced(out string reason) => Evaluate(buildReason: true, out reason);
+
+        private bool Evaluate(bool buildReason, out string reason)
         {
+            // buildReason gates the reason string construction so the boolean only
+            // IsInterlaced() stays allocation free on the hot idet gating path
+            reason = string.Empty;
+
             // Genuinely interlaced content is consistently one field order
             // Use the dominant order and treat the minority order as idet noise
             int interlaced = Math.Max(Tff, Bff);
-            double percentage =
-                Total == 0
-                    ? 0.0
-                    : System.Convert.ToDouble(interlaced) / System.Convert.ToDouble(Total) * 100.0;
-            Debug.Assert(percentage is >= 0.0 and <= 100.0);
-
-            // Frame counts common to every reason string
-            string counts = string.Create(
-                CultureInfo.InvariantCulture,
-                $"TFF: {Tff}, BFF: {Bff}, Progressive: {Progressive}, Undetermined: {Undetermined}, Dominant: {percentage:F2}%"
-            );
 
             // No frames means nothing to decide
             if (Total == 0)
             {
-                reason = $"Progressive: no frames analyzed; {counts}";
+                if (buildReason)
+                {
+                    reason = Describe("Progressive", "no frames analyzed", interlaced);
+                }
                 return false;
             }
 
@@ -188,10 +187,17 @@ public partial class FfMpegIdetInfo
             if (Undetermined >= Determined)
             {
                 // Assume not interlaced
-                reason = string.Create(
-                    CultureInfo.InvariantCulture,
-                    $"Progressive: undetermined frames ({Undetermined}) outnumber determined frames ({Determined}); {counts}"
-                );
+                if (buildReason)
+                {
+                    reason = Describe(
+                        "Progressive",
+                        string.Create(
+                            CultureInfo.InvariantCulture,
+                            $"undetermined frames ({Undetermined}) outnumber determined frames ({Determined})"
+                        ),
+                        interlaced
+                    );
+                }
                 return false;
             }
 
@@ -200,18 +206,45 @@ public partial class FfMpegIdetInfo
             // and we would rather miss interlaced content than deinterlace progressive content
             if (interlaced > Progressive)
             {
-                reason = string.Create(
-                    CultureInfo.InvariantCulture,
-                    $"Interlaced: dominant field order ({interlaced}) outnumbers progressive frames ({Progressive}); {counts}"
-                );
+                if (buildReason)
+                {
+                    reason = Describe(
+                        "Interlaced",
+                        string.Create(
+                            CultureInfo.InvariantCulture,
+                            $"dominant field order ({interlaced}) outnumbers progressive frames ({Progressive})"
+                        ),
+                        interlaced
+                    );
+                }
                 return true;
             }
 
-            reason = string.Create(
-                CultureInfo.InvariantCulture,
-                $"Progressive: dominant field order ({interlaced}) does not outnumber progressive frames ({Progressive}); {counts}"
-            );
+            if (buildReason)
+            {
+                reason = Describe(
+                    "Progressive",
+                    string.Create(
+                        CultureInfo.InvariantCulture,
+                        $"dominant field order ({interlaced}) does not outnumber progressive frames ({Progressive})"
+                    ),
+                    interlaced
+                );
+            }
             return false;
+        }
+
+        private string Describe(string verdict, string rationale, int interlaced)
+        {
+            double percentage =
+                Total == 0
+                    ? 0.0
+                    : System.Convert.ToDouble(interlaced) / System.Convert.ToDouble(Total) * 100.0;
+            Debug.Assert(percentage is >= 0.0 and <= 100.0);
+            return string.Create(
+                CultureInfo.InvariantCulture,
+                $"{verdict}: {rationale}; TFF: {Tff}, BFF: {Bff}, Progressive: {Progressive}, Undetermined: {Undetermined}, Dominant: {percentage:F2}%"
+            );
         }
     }
 }

--- a/PlexCleaner/FfMpegIdetInfo.cs
+++ b/PlexCleaner/FfMpegIdetInfo.cs
@@ -193,7 +193,7 @@ public partial class FfMpegIdetInfo
                         "Progressive",
                         string.Create(
                             CultureInfo.InvariantCulture,
-                            $"undetermined frames ({Undetermined}) outnumber determined frames ({Determined})"
+                            $"determined frames ({Determined}) do not outnumber undetermined frames ({Undetermined})"
                         ),
                         interlaced
                     );

--- a/PlexCleaner/FfMpegIdetInfo.cs
+++ b/PlexCleaner/FfMpegIdetInfo.cs
@@ -62,9 +62,9 @@ public partial class FfMpegIdetInfo
 
     public bool IsInterlaced() => IsInterlaced(out _);
 
-    public bool IsInterlaced(out double percentage) =>
+    public bool IsInterlaced(out string reason) =>
         // MultiFrame is idet's temporally aware and more reliable detector, SingleFrame is noisier
-        MultiFrame.IsInterlaced(out percentage);
+        MultiFrame.IsInterlaced(out reason);
 
     public static bool GetIdetInfo(string fileName, out FfMpegIdetInfo? idetInfo, out string error)
     {
@@ -80,13 +80,6 @@ public partial class FfMpegIdetInfo
         // Parse the text
         idetInfo = new FfMpegIdetInfo();
         return idetInfo.Parse(text);
-    }
-
-    public void WriteLine()
-    {
-        RepeatedFields.WriteLine(nameof(RepeatedFields));
-        SingleFrame.WriteLine(nameof(SingleFrame));
-        MultiFrame.WriteLine(nameof(MultiFrame));
     }
 
     internal bool Parse(string text)
@@ -155,15 +148,6 @@ public partial class FfMpegIdetInfo
         public int Top { get; set; }
         public int Bottom { get; set; }
         public int Total => Neither + Top + Bottom;
-
-        public void WriteLine(string prefix) =>
-            Log.Information(
-                "{Prefix} : Neither: {Neither}, Top: {Top}, Bottom: {Bottom}",
-                prefix,
-                Neither,
-                Top,
-                Bottom
-            );
     }
 
     public class Frames
@@ -176,43 +160,58 @@ public partial class FfMpegIdetInfo
         public int Determined => Interlaced + Progressive;
         public int Total => Tff + Bff + Progressive + Undetermined;
 
-        public bool IsInterlaced(out double percentage)
+        public bool IsInterlaced(out string reason)
         {
             // Genuinely interlaced content is consistently one field order
             // Use the dominant order and treat the minority order as idet noise
             int interlaced = Math.Max(Tff, Bff);
-            percentage =
+            double percentage =
                 Total == 0
                     ? 0.0
                     : System.Convert.ToDouble(interlaced) / System.Convert.ToDouble(Total) * 100.0;
             Debug.Assert(percentage is >= 0.0 and <= 100.0);
 
+            // Frame counts common to every reason string
+            string counts = string.Create(
+                CultureInfo.InvariantCulture,
+                $"TFF: {Tff}, BFF: {Bff}, Progressive: {Progressive}, Undetermined: {Undetermined}, Dominant: {percentage:F2}%"
+            );
+
+            // No frames means nothing to decide
+            if (Total == 0)
+            {
+                reason = $"Progressive: no frames analyzed; {counts}";
+                return false;
+            }
+
             // Need a determined majority to make a reliable call
             if (Undetermined >= Determined)
             {
                 // Assume not interlaced
+                reason = string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"Progressive: undetermined frames ({Undetermined}) outnumber determined frames ({Determined}); {counts}"
+                );
                 return false;
             }
 
             // Interlaced only when the dominant field order outnumbers progressive frames
             // Bias toward progressive, a few percent of interlaced frames is normal idet noise
             // and we would rather miss interlaced content than deinterlace progressive content
-            return interlaced > Progressive;
-        }
+            if (interlaced > Progressive)
+            {
+                reason = string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"Interlaced: dominant field order ({interlaced}) outnumbers progressive frames ({Progressive}); {counts}"
+                );
+                return true;
+            }
 
-        public void WriteLine(string prefix)
-        {
-            bool interlaced = IsInterlaced(out double percentage);
-            Log.Information(
-                "{Prefix} : Interlaced: {Interlaced} ({Percentage:F2}%), TFF: {TFF}, BFF: {BFF}, Progressive: {Progressive}, Undetermined: {Undetermined}",
-                prefix,
-                interlaced,
-                percentage,
-                Tff,
-                Bff,
-                Progressive,
-                Undetermined
+            reason = string.Create(
+                CultureInfo.InvariantCulture,
+                $"Progressive: dominant field order ({interlaced}) does not outnumber progressive frames ({Progressive}); {counts}"
             );
+            return false;
         }
     }
 }

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -1286,7 +1286,9 @@ public class ProcessFile
         // Detected: interlaced video, idetInfo is set when the idet scan detected it, else a metadata flag
         if (idetInfo != null)
         {
-            _ = idetInfo.IsInterlaced(out string reason);
+            // idetInfo is only set when the idet scan detected interlaced content
+            bool interlaced = idetInfo.IsInterlaced(out string reason);
+            Debug.Assert(interlaced);
             Log.Warning(
                 "Interlaced video detected : Format: {Format}, Detected by: Idet, {Reason} : {FileName}",
                 videoProps.Format,

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -1286,16 +1286,11 @@ public class ProcessFile
         // Detected: interlaced video, idetInfo is set when the idet scan detected it, else a metadata flag
         if (idetInfo != null)
         {
-            FfMpegIdetInfo.Frames multiFrame = idetInfo.MultiFrame;
-            _ = idetInfo.IsInterlaced(out double percentage);
+            _ = idetInfo.IsInterlaced(out string reason);
             Log.Warning(
-                "Interlaced video detected : Format: {Format}, Detected by: Idet, MultiFrame: {Percentage:F2}% (TFF: {TFF}, BFF: {BFF}, Progressive: {Progressive}, Undetermined: {Undetermined}) : {FileName}",
+                "Interlaced video detected : Format: {Format}, Detected by: Idet, {Reason} : {FileName}",
                 videoProps.Format,
-                percentage,
-                multiFrame.Tff,
-                multiFrame.Bff,
-                multiFrame.Progressive,
-                multiFrame.Undetermined,
+                reason,
                 FileInfo.FullName
             );
         }
@@ -2406,8 +2401,6 @@ public class ProcessFile
             return false;
         }
 
-        // Log result
-        idetInfo.WriteLine();
         return true;
     }
 

--- a/PlexCleanerTests/FfMpegIdetDecisionTests.cs
+++ b/PlexCleanerTests/FfMpegIdetDecisionTests.cs
@@ -49,7 +49,13 @@ public class FfMpegIdetDecisionTests
     [Theory]
     // tff, bff, progressive, undetermined, reason fragment describing the decision rationale
     [InlineData(0, 0, 0, 0, "no frames analyzed")]
-    [InlineData(100, 0, 50, 200, "undetermined frames (200) outnumber determined frames (150)")]
+    [InlineData(
+        100,
+        0,
+        50,
+        200,
+        "determined frames (150) do not outnumber undetermined frames (200)"
+    )]
     [InlineData(
         6000,
         0,

--- a/PlexCleanerTests/FfMpegIdetDecisionTests.cs
+++ b/PlexCleanerTests/FfMpegIdetDecisionTests.cs
@@ -30,7 +30,49 @@ public class FfMpegIdetDecisionTests
                 Undetermined = und,
             },
         };
-        _ = idet.IsInterlaced().Should().Be(expected);
+        bool interlaced = idet.IsInterlaced(out string reason);
+        _ = interlaced.Should().Be(expected);
+
+        // The reason string leads with the verdict and carries the frame counts
+        _ = reason.Should().StartWith(expected ? "Interlaced:" : "Progressive:");
+        _ = reason.Should().Contain($"TFF: {tff}");
+        _ = reason.Should().Contain($"BFF: {bff}");
+        _ = reason.Should().Contain($"Progressive: {prog}");
+        _ = reason.Should().Contain($"Undetermined: {und}");
+    }
+
+    [Theory]
+    // tff, bff, progressive, undetermined, reason fragment describing the decision rationale
+    [InlineData(0, 0, 0, 0, "no frames analyzed")]
+    [InlineData(100, 0, 50, 200, "undetermined frames (200) outnumber determined frames (150)")]
+    [InlineData(
+        6000,
+        0,
+        4000,
+        0,
+        "dominant field order (6000) outnumbers progressive frames (4000)"
+    )]
+    [InlineData(
+        50,
+        500,
+        4000,
+        0,
+        "dominant field order (500) does not outnumber progressive frames (4000)"
+    )]
+    public void IsInterlaced_ReasonRationale(int tff, int bff, int prog, int und, string fragment)
+    {
+        FfMpegIdetInfo idet = new()
+        {
+            MultiFrame = new FfMpegIdetInfo.Frames
+            {
+                Tff = tff,
+                Bff = bff,
+                Progressive = prog,
+                Undetermined = und,
+            },
+        };
+        _ = idet.IsInterlaced(out string reason);
+        _ = reason.Should().Contain(fragment);
     }
 
     [Fact]

--- a/PlexCleanerTests/FfMpegIdetDecisionTests.cs
+++ b/PlexCleanerTests/FfMpegIdetDecisionTests.cs
@@ -39,6 +39,11 @@ public class FfMpegIdetDecisionTests
         _ = reason.Should().Contain($"BFF: {bff}");
         _ = reason.Should().Contain($"Progressive: {prog}");
         _ = reason.Should().Contain($"Undetermined: {und}");
+
+        // Dominant is the dominant field order as a percentage of all frames
+        double total = tff + bff + prog + und;
+        double dominant = total == 0.0 ? 0.0 : Math.Max(tff, bff) / total * 100.0;
+        _ = reason.Should().Contain(FormattableString.Invariant($"Dominant: {dominant:F2}%"));
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

Follow-up to #809. Consolidates the interlaced detection decision and its human-readable justification inside the idet types so callers no longer make assumptions about the underlying detector.

- Replace `IsInterlaced(out double percentage)` with `IsInterlaced(out string reason)` on both `FfMpegIdetInfo` and `FfMpegIdetInfo.Frames`. The decision logic is unchanged; it now emits a structured, single-line `reason` string stating the verdict, the deciding rationale, and the TFF/BFF/Progressive/Undetermined counts plus dominant field-order percentage.
- `ProcessFile.DeInterlace` logs the `reason` string directly instead of reaching into `idetInfo.MultiFrame` and re-deriving the percentage.
- Delete `FfMpegIdetInfo.WriteLine()` (and the now-unused `Repeated.WriteLine` / `Frames.WriteLine` helpers), which logged three lines per idet scan while only the MultiFrame pass ever fed the decision. The remaining `reason` is logged only on a positive detection.

## Reason string examples

- `Interlaced: dominant field order (6000) outnumbers progressive frames (4000); TFF: 6000, BFF: 0, Progressive: 4000, Undetermined: 0, Dominant: 60.00%`
- `Progressive: undetermined frames (200) outnumber determined frames (150); TFF: 100, ...`
- `Progressive: no frames analyzed; TFF: 0, ...`

## Testing

- `dotnet build` clean (0 warnings, 0 errors).
- `dotnet test` — `FfMpegIdetDecisionTests` extended to validate the reason text (verdict prefix, frame counts, and each rationale branch); all 13 cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)