### PR TITLE
Enable closed caption removal for H.265/HEVC video

### DIFF
--- a/Docs/ClosedCaptions.md
+++ b/Docs/ClosedCaptions.md
@@ -183,4 +183,4 @@ ffmpeg -loglevel error -i [in-filename] -c copy -map 0 -bsf:v filter_units=remov
 
 Closed captions SEI unit for H264 is `6`, `39` for H265, and `178` for MPEG2.
 
-> **ℹ️ Note**: [Wiki](https://trac.ffmpeg.org/wiki/HowToExtractAndRemoveClosedCaptions) and [issue](https://trac.ffmpeg.org/ticket/5283); as of writing HDR10+ metadata may be lost when removing closed captions from H265 content. PlexCleaner therefore skips closed caption removal on H265/HEVC content carrying HDR10+ dynamic metadata (SMPTE ST 2094), reporting it as an error rather than risk stripping the metadata.
+> **ℹ️ Note**: [Wiki](https://trac.ffmpeg.org/wiki/HowToExtractAndRemoveClosedCaptions) and [issue](https://trac.ffmpeg.org/ticket/5283); as of writing HDR10+ metadata may be lost when removing closed captions from H265 content. PlexCleaner therefore skips closed caption removal on H265/HEVC content carrying HDR10 (SMPTE ST 2086) or HDR10+ (SMPTE ST 2094) metadata, reporting it as an error rather than risk stripping the metadata.

--- a/Docs/ClosedCaptions.md
+++ b/Docs/ClosedCaptions.md
@@ -183,4 +183,4 @@ ffmpeg -loglevel error -i [in-filename] -c copy -map 0 -bsf:v filter_units=remov
 
 Closed captions SEI unit for H264 is `6`, `39` for H265, and `178` for MPEG2.
 
-> **ℹ️ Note**: [Wiki](https://trac.ffmpeg.org/wiki/HowToExtractAndRemoveClosedCaptions) and [issue](https://trac.ffmpeg.org/ticket/5283); as of writing HDR10+ metadata may be lost when removing closed captions from H265 content.
+> **ℹ️ Note**: [Wiki](https://trac.ffmpeg.org/wiki/HowToExtractAndRemoveClosedCaptions) and [issue](https://trac.ffmpeg.org/ticket/5283); as of writing HDR10+ metadata may be lost when removing closed captions from H265 content. PlexCleaner therefore skips closed caption removal on H265/HEVC content carrying HDR10+ dynamic metadata (SMPTE ST 2094), reporting it as an error rather than risk stripping the metadata.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 ## Release History
 
 - Version 3.20:
+  - Enabled closed caption removal for H.265/HEVC video: the SEI NAL unit lookup keyed on `h265` never matched FFprobe's `hevc` codec name, so HEVC files were incorrectly reported as an "Unsupported video format for Closed Captions removal". HEVC content (excluding HDR10+, which remains guarded) is now cleaned using the `filter_units=remove_types=39` bitstream filter, same as H.264 and MPEG-2.
   - Added per-file stateful log level filtering to enable information level output after a warning or error event is detected, overriding the `--logwarning` warning only filter. Prior to this change the log output would only contain the trigger warning or error event, now it will also log all subsequent information level events for that file during its processing cycle.
   - Log a warning when a repair or cleanup condition is detected (redundant `Default` flags, invalid language tags, interlaced video, tracks needing re-encode, etc.) so `--logwarning` surfaces every file that is modified, with the subsequent cleanup steps logged at information level.
   - Always log the end-of-run summary at information level, even with `--logwarning`, so the modified, error, and verify-failed counts are recorded for every processing run.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 ## Release History
 
 - Version 3.20:
-  - Enabled closed caption removal for H.265/HEVC video: the SEI NAL unit lookup keyed on `h265` never matched FFprobe's `hevc` codec name, so HEVC files were incorrectly reported as an "Unsupported video format for Closed Captions removal". HEVC content (excluding HDR10+, which remains guarded) is now cleaned using the `filter_units=remove_types=39` bitstream filter, same as H.264 and MPEG-2.
+  - Enabled closed caption removal for H.265/HEVC video: the SEI NAL unit lookup keyed on `h265` never matched FFprobe's `hevc` codec name, so HEVC files were incorrectly reported as an "Unsupported video format for Closed Captions removal". HEVC content (excluding HDR10 and HDR10+, which remains guarded) is now cleaned using the `filter_units=remove_types=39` bitstream filter, same as H.264 and MPEG-2.
   - Added per-file stateful log level filtering to enable information level output after a warning or error event is detected, overriding the `--logwarning` warning only filter. Prior to this change the log output would only contain the trigger warning or error event, now it will also log all subsequent information level events for that file during its processing cycle.
   - Log a warning when a repair or cleanup condition is detected (redundant `Default` flags, invalid language tags, interlaced video, tracks needing re-encode, etc.) so `--logwarning` surfaces every file that is modified, with the subsequent cleanup steps logged at information level.
   - Always log the end-of-run summary at information level, even with `--logwarning`, so the modified, error, and verify-failed counts are recorded for every processing run.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 ## Release History
 
 - Version 3.20:
-  - Enabled closed caption removal for H.265/HEVC video: the SEI NAL unit lookup keyed on `h265` never matched FFprobe's `hevc` codec name, so HEVC files were incorrectly reported as an "Unsupported video format for Closed Captions removal". HEVC content (excluding HDR10 and HDR10+, which remains guarded) is now cleaned using the `filter_units=remove_types=39` bitstream filter, same as H.264 and MPEG-2.
+  - Enabled closed caption removal for H.265/HEVC video: the SEI NAL unit lookup keyed on `h265` never matched FFprobe's `hevc` codec name, so HEVC files were incorrectly reported as an "Unsupported video format for Closed Captions removal". HEVC video (excluding HDR10 and HDR10+ content, which remains guarded) is now cleaned using the `filter_units=remove_types=39` bitstream filter, same as H.264 and MPEG-2.
   - Added per-file stateful log level filtering to enable information level output after a warning or error event is detected, overriding the `--logwarning` warning only filter. Prior to this change the log output would only contain the trigger warning or error event, now it will also log all subsequent information level events for that file during its processing cycle.
   - Log a warning when a repair or cleanup condition is detected (redundant `Default` flags, invalid language tags, interlaced video, tracks needing re-encode, etc.) so `--logwarning` surfaces every file that is modified, with the subsequent cleanup steps logged at information level.
   - Always log the end-of-run summary at information level, even with `--logwarning`, so the modified, error, and verify-failed counts are recorded for every processing run.

--- a/PlexCleaner/FfMpegTool.cs
+++ b/PlexCleaner/FfMpegTool.cs
@@ -21,7 +21,7 @@ public partial class FfMpeg
 
     // Common format tags
     private const string H264Format = "h264";
-    private const string H265Format = "h265";
+    private const string H265Format = "hevc";
     private const string MPEG2Format = "mpeg2video";
 
     // SEI NAL units for EIA-608 and CTA-708 content
@@ -34,7 +34,7 @@ public partial class FfMpeg
 
     public static int GetNalUnit(string format) =>
         // Get SEI NAL unit based on video format
-        // H264 = 6, H265 = 9, MPEG2 = 178
+        // H264 = 6, H265/HEVC = 39, MPEG2 = 178
         // Return default(int) if not found
         s_sEINalUnitList
             .FirstOrDefault(item => item.format.Equals(format, StringComparison.OrdinalIgnoreCase))

--- a/PlexCleanerTests/FfMpegNalUnitTests.cs
+++ b/PlexCleanerTests/FfMpegNalUnitTests.cs
@@ -1,0 +1,25 @@
+using AwesomeAssertions;
+using PlexCleaner;
+using Xunit;
+
+namespace PlexCleanerTests;
+
+public class FfMpegNalUnitTests
+{
+    [Theory]
+    // Format strings match FfProbe codec_name / MediaInfo format tags
+    [InlineData("h264", 6)]
+    [InlineData("hevc", 39)]
+    [InlineData("mpeg2video", 178)]
+    [InlineData("HEVC", 39)] // Case insensitive
+    public void GetNalUnit_KnownFormat_ReturnsSeiNalUnit(string format, int expected) =>
+        _ = FfMpeg.GetNalUnit(format).Should().Be(expected);
+
+    [Theory]
+    [InlineData("h265")] // FfProbe reports HEVC as "hevc", not "h265"
+    [InlineData("av1")]
+    [InlineData("vp9")]
+    [InlineData("")]
+    public void GetNalUnit_UnsupportedFormat_ReturnsZero(string format) =>
+        _ = FfMpeg.GetNalUnit(format).Should().Be(0);
+}

--- a/PlexCleanerTests/FfMpegNalUnitTests.cs
+++ b/PlexCleanerTests/FfMpegNalUnitTests.cs
@@ -7,7 +7,7 @@ namespace PlexCleanerTests;
 public class FfMpegNalUnitTests
 {
     [Theory]
-    // Format strings match FfProbe codec_name / MediaInfo format tags
+    // Format strings are FFprobe codec_name tokens (the value passed to GetNalUnit)
     [InlineData("h264", 6)]
     [InlineData("hevc", 39)]
     [InlineData("mpeg2video", 178)]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 - Always log the end-of-run summary, and handle stop signals (`docker stop`, `Ctrl+C`) so processing stops gracefully and the summary and exit code are logged before exit.
 - Normalize multiple or redundant `Default` track flags instead of only warning about them.
 - Added a `custom` command that runs a user-provided plugin assembly over the media files for bespoke re-processing or repair, see [Custom Plugins](#custom-plugins).
-- Fixed closed caption removal for H.265/HEVC video that was incorrectly reported as an unsupported format (HDR10 and HDR10+ HEVC remains guarded).
+- Fixed closed caption removal for H.265/HEVC video that was incorrectly reported as an unsupported format (HDR10 and HDR10+ HEVC content remains guarded).
 
 See [Release History](./HISTORY.md) for complete release notes and older versions.
 
@@ -507,7 +507,7 @@ Refer to [Docs/LanguageMatching.md](./Docs/LanguageMatching.md) for technical de
 
 ### EIA-608 and CTA-708 Closed Captions
 
-> **ℹ️ TL;DR**: Closed captions (CC) are subtitles embedded in the video stream (not separate tracks). They can cause issues with some players that always display them or cannot disable them. PlexCleaner can detect and remove them using the `RemoveClosedCaptions` option. Removal is supported for H.264, H.265/HEVC, and MPEG-2 video (HDR10 and HDR10+ HEVC is skipped to avoid stripping HDR metadata).
+> **ℹ️ TL;DR**: Closed captions (CC) are subtitles embedded in the video stream (not separate tracks). They can cause issues with some players that always display them or cannot disable them. PlexCleaner can detect and remove them using the `RemoveClosedCaptions` option. Removal is supported for H.264, H.265/HEVC, and MPEG-2 video (HDR10 and HDR10+ HEVC content is skipped to avoid stripping HDR metadata).
 
 Refer to [Docs/ClosedCaptions.md](./Docs/ClosedCaptions.md) for technical details on detection and removal methods.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 - Always log the end-of-run summary, and handle stop signals (`docker stop`, `Ctrl+C`) so processing stops gracefully and the summary and exit code are logged before exit.
 - Normalize multiple or redundant `Default` track flags instead of only warning about them.
 - Added a `custom` command that runs a user-provided plugin assembly over the media files for bespoke re-processing or repair, see [Custom Plugins](#custom-plugins).
+- Fixed closed caption removal for H.265/HEVC video that was incorrectly reported as an unsupported format.
 
 See [Release History](./HISTORY.md) for complete release notes and older versions.
 
@@ -506,7 +507,7 @@ Refer to [Docs/LanguageMatching.md](./Docs/LanguageMatching.md) for technical de
 
 ### EIA-608 and CTA-708 Closed Captions
 
-> **ℹ️ TL;DR**: Closed captions (CC) are subtitles embedded in the video stream (not separate tracks). They can cause issues with some players that always display them or cannot disable them. PlexCleaner can detect and remove them using the `RemoveClosedCaptions` option.
+> **ℹ️ TL;DR**: Closed captions (CC) are subtitles embedded in the video stream (not separate tracks). They can cause issues with some players that always display them or cannot disable them. PlexCleaner can detect and remove them using the `RemoveClosedCaptions` option. Removal is supported for H.264, H.265/HEVC, and MPEG-2 video (HDR10+ HEVC is skipped to avoid stripping dynamic metadata).
 
 Refer to [Docs/ClosedCaptions.md](./Docs/ClosedCaptions.md) for technical details on detection and removal methods.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 - Always log the end-of-run summary, and handle stop signals (`docker stop`, `Ctrl+C`) so processing stops gracefully and the summary and exit code are logged before exit.
 - Normalize multiple or redundant `Default` track flags instead of only warning about them.
 - Added a `custom` command that runs a user-provided plugin assembly over the media files for bespoke re-processing or repair, see [Custom Plugins](#custom-plugins).
-- Fixed closed caption removal for H.265/HEVC video that was incorrectly reported as an unsupported format.
+- Fixed closed caption removal for H.265/HEVC video that was incorrectly reported as an unsupported format (HDR10 and HDR10+ HEVC remains guarded).
 
 See [Release History](./HISTORY.md) for complete release notes and older versions.
 
@@ -507,7 +507,7 @@ Refer to [Docs/LanguageMatching.md](./Docs/LanguageMatching.md) for technical de
 
 ### EIA-608 and CTA-708 Closed Captions
 
-> **ℹ️ TL;DR**: Closed captions (CC) are subtitles embedded in the video stream (not separate tracks). They can cause issues with some players that always display them or cannot disable them. PlexCleaner can detect and remove them using the `RemoveClosedCaptions` option. Removal is supported for H.264, H.265/HEVC, and MPEG-2 video (HDR10+ HEVC is skipped to avoid stripping dynamic metadata).
+> **ℹ️ TL;DR**: Closed captions (CC) are subtitles embedded in the video stream (not separate tracks). They can cause issues with some players that always display them or cannot disable them. PlexCleaner can detect and remove them using the `RemoveClosedCaptions` option. Removal is supported for H.264, H.265/HEVC, and MPEG-2 video (HDR10 and HDR10+ HEVC is skipped to avoid stripping HDR metadata).
 
 Refer to [Docs/ClosedCaptions.md](./Docs/ClosedCaptions.md) for technical details on detection and removal methods.
 


### PR DESCRIPTION
## Problem

Closed caption removal failed for every H.265/HEVC file, logging:

```
[ERR] Unsupported video format for Closed Captions removal : Format: "hevc"
```

Detection worked (FFprobe `subcc` reported `CC: True`), but removal aborted. The SEI NAL unit lookup in `FfMpeg.GetNalUnit()` was keyed on the format tag `"h265"`, while FFprobe reports the codec name as `"hevc"`. The string never matched, so the lookup returned `0` and the file was treated as an unsupported format. HEVC removal was effectively gated by a codec name FFprobe never emits (`MediaInfoTool` already used `"hevc"` correctly).

## Fix

- Align `FfMpegTool` `H265Format` with FFprobe's codec name (`"h265"` → `"hevc"`) so `GetNalUnit("hevc")` returns `39` and HEVC content is cleaned via `filter_units=remove_types=39`, same path as H.264 and MPEG-2.
- Corrected a stale code comment (`H265 = 9` → `H265/HEVC = 39`).
- The HDR10+ guard is intentionally left in place — stripping type-39 SEI would also remove HDR10+ dynamic metadata, and there is no HDR10+ sample to validate against.

## Verification

Validated end to end against an HEVC sample carrying closed captions:

- Manual `filter_units=remove_types=39`: source clip 666 CC packets → 0, frame count preserved (31184), clean decode.
- Full `removeclosedcaptions` run: detected `CC: True`, ran the removal + remux, re-detected `CC: False` across all three tools, 31184 frames intact, exit code 0.
- Added `FfMpegNalUnitTests` covering `hevc→39`, `h264→6`, `mpeg2video→178`, case-insensitivity, and that unsupported formats (including the old `h265`) return `0`.

## Docs

Updated HISTORY, README release notes + closed captions section, and `Docs/ClosedCaptions.md` to reflect that HEVC removal is supported and HDR10+ HEVC is deliberately skipped.