### PR TITLE
merge-bot: auto-merge every Dependabot tier on main (drop semver-major skip)

### DIFF
--- a/.github/workflows/merge-bot-pull-request.yml
+++ b/.github/workflows/merge-bot-pull-request.yml
@@ -41,17 +41,8 @@ jobs:
           client-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
           private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
 
-      - name: Get dependabot metadata step
-        id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      # Skip semver-major NuGet bumps so they land via human review; other ecosystems' majors auto-merge.
+      # Auto-merge every tier, semver-major included: the required checks are the gate, not the bump magnitude.
       - name: Merge pull request step
-        if: >-
-          (steps.metadata.outputs.package-ecosystem != 'nuget') ||
-          (steps.metadata.outputs.update-type != 'version-update:semver-major')
         run: |
           set -euo pipefail
           case "${{ github.event.pull_request.base.ref }}" in


### PR DESCRIPTION
Applies the every-tier merge-bot policy to **`main`** (tracking #799).

The fix already merged to `develop` (#799), but `main` still carries the semver-major NuGet skip. Since `develop` is well ahead with unreleased feature work, this is a **surgical `main`-only** change rather than a full promotion: drop the `version-update:semver-major` NuGet guard and the now-unused `dependabot/fetch-metadata` step that fed it. The required CI checks are the gate, not the bump magnitude.

- CRLF preserved (no EOL churn); YAML parses; no residual `fetch-metadata`/`package-ecosystem`/`update-type` references.
- Mirrors ProjectTemplate #266 and the `develop` implementation.

Note: at the next `develop`->`main` promotion the merge-bot file will reconcile to `develop`'s version (same net effect); resolve in favour of `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)