### PR TITLE
Do not log an empty error line on tool cancellation

### DIFF
--- a/PlexCleaner/FfProbeTool.cs
+++ b/PlexCleaner/FfProbeTool.cs
@@ -20,6 +20,15 @@ public partial class FfProbe
         // "Undesirable" tags
         private static readonly List<string> s_undesirableTags = ["statistics"];
 
+        // Skip empty stderr, e.g. a cancelled process, to avoid logging an empty "" line
+        internal static void LogErrorOutput(string error)
+        {
+            if (!string.IsNullOrWhiteSpace(error))
+            {
+                Log.Error("{Error}", error);
+            }
+        }
+
         public override ToolFamily GetToolFamily() => ToolFamily.FfMpeg;
 
         public override ToolType GetToolType() => ToolType.FfProbe;
@@ -226,7 +235,7 @@ public partial class FfProbe
                 if (!Tools.FfMpeg.Execute(command, true, true, out BufferedCommandResult result))
                 {
                     Log.Error("Failed to create temp media file : {TempFileName}", tempName);
-                    Log.Error("{Error}", result.StandardError.Trim());
+                    LogErrorOutput(result.StandardError.Trim());
                     File.Delete(tempName);
                     return false;
                 }
@@ -256,7 +265,7 @@ public partial class FfProbe
             if (!ret)
             {
                 Log.Error("Failed to get subcc packet info : {FileName}", fileName);
-                Log.Error("{Error}", error);
+                LogErrorOutput(error);
             }
             if (Program.Options.QuickScan)
             {
@@ -284,7 +293,7 @@ public partial class FfProbe
             if (!GetPackets(command, packetFunc, out string error))
             {
                 Log.Error("Failed to get bitrate packets : {FileName}", fileName);
-                Log.Error("{Error}", error);
+                LogErrorOutput(error);
                 return false;
             }
             return true;

--- a/PlexCleanerTests/FfProbeLogTests.cs
+++ b/PlexCleanerTests/FfProbeLogTests.cs
@@ -1,0 +1,57 @@
+using System.Globalization;
+using AwesomeAssertions;
+using PlexCleaner;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Xunit;
+
+namespace PlexCleanerTests;
+
+public class FfProbeLogTests
+{
+    private sealed class CapturingSink : ILogEventSink
+    {
+        public List<LogEvent> Events { get; } = [];
+
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+    }
+
+    // Capture events emitted during the action by temporarily redirecting the static Serilog logger
+    private static List<LogEvent> Capture(Action action)
+    {
+        CapturingSink sink = new();
+        ILogger original = Log.Logger;
+        Logger capture = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        Log.Logger = capture;
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Log.Logger = original;
+            capture.Dispose();
+        }
+        return sink.Events;
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   \r\n  ")]
+    public void LogErrorOutput_EmptyOrWhitespace_LogsNothing(string error) =>
+        // A cancelled process produces no stderr; do not log an empty "" line
+        _ = Capture(() => FfProbe.Tool.LogErrorOutput(error)).Should().BeEmpty();
+
+    [Fact]
+    public void LogErrorOutput_WithText_LogsAsError()
+    {
+        List<LogEvent> events = Capture(() => FfProbe.Tool.LogErrorOutput("boom"));
+        _ = events.Should().ContainSingle();
+        _ = events[0].Level.Should().Be(LogEventLevel.Error);
+        _ = events[0].RenderMessage(CultureInfo.InvariantCulture).Should().Contain("boom");
+    }
+}


### PR DESCRIPTION
## Problem

When a run is cancelled (`SIGTERM`), FfProbe operations log an empty `""` error line:

```
[WRN] Operation interrupted : SIGTERM
[ERR] Cancelled execution of FfProbe : ...
[ERR] Failed to get subcc packet info : "/media/.../file.mkv"
[ERR] ""
[ERR] Failed to find Closed Captions in video stream : "/media/.../file.mkv"
```

`FfProbeTool` logged the tool stderr as a second error line unconditionally (`Log.Error("{Error}", error)`) in the subcc, bitrate, and temp-file paths. A cancelled process is killed before writing to stderr, so `error` is empty and Serilog's `{Message}` template renders it as `""`.

This is separate from #821 (which fixed the misplaced quote on the `ExitCode` line).

## Fix

Route the three sites through a `LogErrorOutput` helper that logs only when the stderr is non-empty (`!string.IsNullOrWhiteSpace`). Adds tests for the helper (empty/whitespace logs nothing; text logs one Error event).

**196 tests pass**; formatters/linters clean. No HISTORY entry — the log rework and this fix are both within the unreleased 3.20 cycle.