### PR TITLE
Serialize only the log-capture tests, not the whole suite

### DIFF
--- a/PlexCleanerTests/FfProbeLogTests.cs
+++ b/PlexCleanerTests/FfProbeLogTests.cs
@@ -8,6 +8,8 @@ using Xunit;
 
 namespace PlexCleanerTests;
 
+// Sequential because these swap the global Serilog Log.Logger
+[Collection("Sequential")]
 public class FfProbeLogTests
 {
     private sealed class CapturingSink : ILogEventSink

--- a/PlexCleanerTests/PlexCleanerFixture.cs
+++ b/PlexCleanerTests/PlexCleanerFixture.cs
@@ -15,6 +15,11 @@ using ConfigFileJsonSchema = PlexCleaner.ConfigFileJsonSchema4;
 
 namespace PlexCleanerTests;
 
+// Tests that mutate global static state (e.g. swap the Serilog Log.Logger) join this collection so
+// they run sequentially and are not parallelized with the rest of the suite
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public sealed class SequentialCollectionDefinition;
+
 // One instance for all tests in the assembly
 public sealed class PlexCleanerFixture : IDisposable
 {

--- a/PlexCleanerTests/PlexCleanerTests.csproj
+++ b/PlexCleanerTests/PlexCleanerTests.csproj
@@ -3,10 +3,6 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Tests share global state (Program.Options/Config, Serilog Log.Logger), so run serially -->
-    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />

--- a/PlexCleanerTests/ToolFailureLogFormatTests.cs
+++ b/PlexCleanerTests/ToolFailureLogFormatTests.cs
@@ -13,7 +13,8 @@ namespace PlexCleanerTests;
 // The tool-failure log line renders through the app's {Message} output template, which quotes string
 // values. These tests exercise MediaTool.LogFailedResult and verify the ExitCode and error summary
 // format correctly - the error text is quoted as its own value and the " : " separator is not pulled
-// inside the quotes.
+// inside the quotes. Sequential because they swap the global Serilog Log.Logger.
+[Collection("Sequential")]
 public class ToolFailureLogFormatTests
 {
     private sealed class CapturingSink : ILogEventSink

--- a/PlexCleanerTests/xunit.runner.json
+++ b/PlexCleanerTests/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeTestCollections": false
-}


### PR DESCRIPTION
## Problem

#821 added `xunit.runner.json` with `parallelizeTestCollections: false` to fix a race in the tests that swap the global Serilog `Log.Logger`. That disabled parallelization for the **entire** suite, slowing every test.

## Fix

Follow the ptr727/LanguageTags pattern (`LanguageTagsTests/Fixture.cs`): a dedicated collection with `DisableParallelization`, applied only to the classes that need it.

- Removed the assembly-wide `xunit.runner.json`.
- Added `[CollectionDefinition("Sequential", DisableParallelization = true)]`.
- Marked only `ToolFailureLogFormatTests` and `FfProbeLogTests` (the ones that swap `Log.Logger`) with `[Collection("Sequential")]`.

The rest of the suite parallelizes again; the two log-capture classes run sequentially and isolated. **196 tests pass**; local wall-clock is back down (~3s vs ~4s serial). Formatters/linters clean.