### PR TITLE
Use the ptr727.Utilities resilient HTTP client for downloads

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="NEbml" Version="1.1.0.5" />
     <PackageVersion Include="ptr727.LanguageTags" Version="1.5.33" />
-    <PackageVersion Include="ptr727.Utilities" Version="3.7.5" />
+    <PackageVersion Include="ptr727.Utilities" Version="4.0.7" />
     <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 ## Release History
 
 - Version 3.20:
+  - Switched tool downloads and the application version check to the resilient HTTP client in `ptr727.Utilities` (retry with backoff and a circuit breaker via `Microsoft.Extensions.Http.Resilience`), replacing the plain `HttpClient`.
   - Enabled closed caption removal for H.265/HEVC video: the SEI NAL unit lookup keyed on `h265` never matched FFprobe's `hevc` codec name, so HEVC files were incorrectly reported as an "Unsupported video format for Closed Captions removal". HEVC video (excluding HDR10 and HDR10+ content, which remains guarded) is now cleaned using the `filter_units=remove_types=39` bitstream filter, same as H.264 and MPEG-2.
   - Reworked the logging configuration and command line:
     - Added `--loglevel` (`Verbose`, `Debug`, `Information` (default), `Warning`, `Error`, `Fatal`) as the single log level control. `Debug` and `Verbose` output can now be selected; previously `Information` was a hard floor and could not be lowered.

--- a/PlexCleaner/FfMpegTool.cs
+++ b/PlexCleaner/FfMpegTool.cs
@@ -95,7 +95,11 @@ public partial class FfMpeg
                 // Get the latest release version number from github releases
                 // https://github.com/GyanD/codexffmpeg
                 const string repo = "GyanD/codexffmpeg";
-                mediaToolInfo.Version = GetLatestGitHubRelease(repo);
+                if (!GetLatestGitHubRelease(repo, out string version))
+                {
+                    return false;
+                }
+                mediaToolInfo.Version = version;
 
                 // Create the filename using the version number
                 // ffmpeg-6.0-full_build.7z

--- a/PlexCleaner/GitHubRelease.cs
+++ b/PlexCleaner/GitHubRelease.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json.Nodes;
+using ptr727.Utilities;
 using Serilog;
 
 namespace PlexCleaner;
@@ -7,22 +8,26 @@ namespace PlexCleaner;
 // TODO: Convert to JSON Schema class
 public class GitHubRelease
 {
-    // Can throw HTTP exceptions
-    public static string GetLatestRelease(string repo)
+    public static bool GetLatestRelease(string repo, out string version)
     {
+        version = string.Empty;
+
         // Get the latest release version number from github releases
         // https://api.github.com/repos/ptr727/PlexCleaner/releases/latest
         string uri = $"https://api.github.com/repos/{repo}/releases/latest";
         Log.Debug("Getting latest GitHub Release version from : {Uri}", uri);
-        string json = Program.GetHttpClient().GetStringAsync(uri).GetAwaiter().GetResult();
-        Debug.Assert(json != null);
+        if (!Download.DownloadString(new Uri(uri), out string json))
+        {
+            return false;
+        }
 
         // Parse latest version from "tag_name"
         JsonNode? releases = JsonNode.Parse(json);
         Debug.Assert(releases != null);
         JsonNode? versionTag = releases["tag_name"];
         Debug.Assert(versionTag != null);
-        return versionTag.ToString();
+        version = versionTag.ToString();
+        return true;
     }
 
     public static string GetDownloadUri(string repo, string tag, string file) =>

--- a/PlexCleaner/GitHubRelease.cs
+++ b/PlexCleaner/GitHubRelease.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.Json.Nodes;
 using ptr727.Utilities;
 using Serilog;
@@ -21,13 +20,22 @@ public class GitHubRelease
             return false;
         }
 
-        // Parse latest version from "tag_name"
-        JsonNode? releases = JsonNode.Parse(json);
-        Debug.Assert(releases != null);
-        JsonNode? versionTag = releases["tag_name"];
-        Debug.Assert(versionTag != null);
-        version = versionTag.ToString();
-        return true;
+        // Parse latest version from "tag_name"; malformed or unexpected JSON returns false, not throws
+        try
+        {
+            string? versionTag = JsonNode.Parse(json)?["tag_name"]?.ToString();
+            if (string.IsNullOrEmpty(versionTag))
+            {
+                Log.Error("Failed to read tag_name from GitHub release : {Uri}", uri);
+                return false;
+            }
+            version = versionTag;
+            return true;
+        }
+        catch (Exception e) when (Log.Logger.LogAndHandle(e))
+        {
+            return false;
+        }
     }
 
     public static string GetDownloadUri(string repo, string tag, string file) =>

--- a/PlexCleaner/HandBrakeTool.cs
+++ b/PlexCleaner/HandBrakeTool.cs
@@ -68,7 +68,11 @@ public partial class HandBrake
                 // Get the latest release version number from github releases
                 // https://github.com/HandBrake/HandBrake
                 const string repo = "HandBrake/HandBrake";
-                mediaToolInfo.Version = GetLatestGitHubRelease(repo);
+                if (!GetLatestGitHubRelease(repo, out string version))
+                {
+                    return false;
+                }
+                mediaToolInfo.Version = version;
 
                 // Create the filename using the version number
                 // HandBrakeCLI-1.3.2-win-x86_64.zip

--- a/PlexCleaner/MediaInfoTool.cs
+++ b/PlexCleaner/MediaInfoTool.cs
@@ -68,7 +68,11 @@ public partial class MediaInfo
                 // Get the latest release version number from github releases
                 // https://github.com/MediaArea/MediaInfo
                 const string repo = "MediaArea/MediaInfo";
-                mediaToolInfo.Version = GetLatestGitHubRelease(repo);
+                if (!GetLatestGitHubRelease(repo, out string version))
+                {
+                    return false;
+                }
+                mediaToolInfo.Version = version;
 
                 // Strip the "v", v23.09 -> 23.09
                 Debug.Assert(mediaToolInfo.Version.StartsWith('v'));

--- a/PlexCleaner/MediaTool.cs
+++ b/PlexCleaner/MediaTool.cs
@@ -88,11 +88,10 @@ public abstract class MediaTool
             ? GetLatestVersionWindows(out mediaToolInfo)
             : throw new NotImplementedException();
 
-    // Can throw HTTP exceptions
-    protected string GetLatestGitHubRelease(string repo)
+    protected bool GetLatestGitHubRelease(string repo, out string version)
     {
         Log.Debug("{Tool} : Getting latest version from GitHub : {Repo}", GetToolFamily(), repo);
-        return GitHubRelease.GetLatestRelease(repo);
+        return GitHubRelease.GetLatestRelease(repo, out version);
     }
 
     public bool Execute(Command command, out CommandResult commandResult)

--- a/PlexCleaner/MkvMergeTool.cs
+++ b/PlexCleaner/MkvMergeTool.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text.RegularExpressions;
 using CliWrap;
 using CliWrap.Buffered;
+using ptr727.Utilities;
 using Serilog;
 
 // https://mkvtoolnix.download/doc/mkvmerge.html
@@ -75,8 +76,10 @@ public partial class MkvMerge
                 // https://mkvtoolnix.download/latest-release.json
                 const string uri = "https://mkvtoolnix.download/latest-release.json";
                 Log.Debug("{Tool} : Reading latest version from : {Uri}", GetToolFamily(), uri);
-                string json = Program.GetHttpClient().GetStringAsync(uri).GetAwaiter().GetResult();
-                Debug.Assert(json != null);
+                if (!Download.DownloadString(new Uri(uri), out string json))
+                {
+                    return false;
+                }
 
                 // Get the version number from JSON
                 MkvToolJsonSchema.LatestRelease latestRelease =

--- a/PlexCleaner/Program.cs
+++ b/PlexCleaner/Program.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using ptr727.Utilities;
 using Serilog;
@@ -13,7 +12,6 @@ public static class Program
 
     // Exit code for an OS-signal interruption (128 + signal number), else 0; set only by PosixSignalHandler
     private static volatile int s_signalExitCode;
-    private static readonly Lazy<HttpClient> s_httpClient = new(CreateHttpClient);
 
     // Serilog to Microsoft.Extensions.Logging bridge shared with library loggers; lives for the
     // process lifetime and is disposed at shutdown alongside the logger
@@ -23,20 +21,6 @@ public static class Program
     public static readonly TimeSpan QuickScanTimeSpan = TimeSpan.FromMinutes(3);
     public static CommandLineOptions Options { get; set; } = null!;
     public static ConfigFileJsonSchema Config { get; set; } = null!;
-
-    public static HttpClient GetHttpClient() => s_httpClient.Value;
-
-    private static HttpClient CreateHttpClient()
-    {
-        HttpClient httpClient = new() { Timeout = TimeSpan.FromSeconds(120) };
-        httpClient.DefaultRequestHeaders.UserAgent.Add(
-            new ProductInfoHeaderValue(
-                AssemblyVersion.GetName(),
-                AssemblyVersion.GetInformationalVersion()
-            )
-        );
-        return httpClient;
-    }
 
     private static int MakeExitCode(ExitCode exitCode) => (int)exitCode;
 
@@ -142,12 +126,17 @@ public static class Program
             return;
         }
 
+        // Get the latest release version from github releases, skip on download failure (already logged)
+        // E.g. 1.2.3
+        const string repo = "ptr727/PlexCleaner";
+        if (!GitHubRelease.GetLatestRelease(repo, out string latest))
+        {
+            return;
+        }
+
         try
         {
-            // Get the latest release version from github releases
-            // E.g. 1.2.3
-            const string repo = "ptr727/PlexCleaner";
-            Version latestVersion = new(GitHubRelease.GetLatestRelease(repo));
+            Version latestVersion = new(latest);
 
             // Get this version
             Version thisVersion = new(AssemblyVersion.GetReleaseVersion());

--- a/PlexCleaner/SevenZipTool.cs
+++ b/PlexCleaner/SevenZipTool.cs
@@ -67,7 +67,11 @@ public partial class SevenZip
                 // Get the latest release version number from github releases
                 // https://github.com/ip7z/7zip
                 const string repo = "ip7z/7zip";
-                mediaToolInfo.Version = GetLatestGitHubRelease(repo);
+                if (!GetLatestGitHubRelease(repo, out string version))
+                {
+                    return false;
+                }
+                mediaToolInfo.Version = version;
 
                 // Create the filename using the version number
                 // remove the . from the version, 23.01 -> 2301

--- a/PlexCleaner/Tools.cs
+++ b/PlexCleaner/Tools.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using ptr727.Utilities;
 using Serilog;
 
 namespace PlexCleaner;
@@ -335,47 +336,21 @@ public static class Tools
 
     public static bool GetUrlInfo(MediaToolInfo mediaToolInfo)
     {
-        try
-        {
-            using HttpResponseMessage httpResponse = Program
-                .GetHttpClient()
-                .GetAsync(mediaToolInfo.Url)
-                .GetAwaiter()
-                .GetResult()
-                .EnsureSuccessStatusCode();
-
-            mediaToolInfo.Size = httpResponse.Content.Headers.ContentLength ?? 0;
-            mediaToolInfo.ModifiedTime =
-                httpResponse.Content.Headers.LastModified?.DateTime ?? DateTime.MinValue;
-        }
-        catch (HttpRequestException e) when (Log.Logger.LogAndHandle(e))
+        if (
+            !Download.GetContentInfo(
+                new Uri(mediaToolInfo.Url),
+                out long size,
+                out DateTime modifiedTime
+            )
+        )
         {
             return false;
         }
+        mediaToolInfo.Size = size;
+        mediaToolInfo.ModifiedTime = modifiedTime;
         return true;
     }
 
-    public static async Task DownloadFileAsync(Uri uri, string fileName)
-    {
-        await using Stream httpStream = await Program
-            .GetHttpClient()
-            .GetStreamAsync(uri)
-            .ConfigureAwait(false);
-        await using FileStream fileStream = File.OpenWrite(fileName);
-        await httpStream.CopyToAsync(fileStream).ConfigureAwait(false);
-    }
-
-    public static bool DownloadFile(Uri uri, string fileName)
-    {
-        try
-        {
-            DownloadFileAsync(uri, fileName).GetAwaiter().GetResult();
-        }
-        catch (Exception e) when (Log.Logger.LogAndHandle(e))
-        {
-            return false;
-        }
-
-        return true;
-    }
+    public static bool DownloadFile(Uri uri, string fileName) =>
+        Download.DownloadFile(uri, fileName);
 }


### PR DESCRIPTION
## Summary

Switch tool downloads and the app version check from a plain `HttpClient` to the resilient `Download` API in `ptr727.Utilities` v4 — retry with exponential backoff + jitter and a circuit breaker via `Microsoft.Extensions.Http.Resilience` (Polly).

## Changes

- **Bump** `ptr727.Utilities` 3.7.5 → 4.0.7.
- **Remove** `Program.GetHttpClient` / `CreateHttpClient` / `s_httpClient`. The library's factory provides the 120 s timeout (default, matches prior) and a user-agent from the **entry assembly** (`PlexCleaner/<version>`, matches prior — so GitHub's API won't 403). Resilience/retry events log through the `LogOptions` factory already wired in `Program.cs`.
- **`GitHubRelease` / `MkvMergeTool`** → `Download.DownloadString`. `GetLatestRelease` / `GetLatestGitHubRelease` now return `bool` with an `out version`; updated the four tool version-check callers and `VerifyLatestVersion`.
- **`Tools.GetUrlInfo`** → `Download.GetContentInfo` (size + last-modified); **`Tools.DownloadFile`** delegates to `Download.DownloadFile`; the manual `DownloadFileAsync` is removed.

No functionality lost — v4's `Download` covers file/string/content-info, and the entry-assembly user-agent + 120 s timeout match the previous manual setup.

## Verification

- Build clean (0 warnings), **196 tests pass**, formatters/linters green.
- One-off network check confirmed `Download.DownloadString` reaches the GitHub releases API and returns valid JSON (user-agent works, no 403). The tool-download/auto-update paths are Windows-only, so they can't be driven on the Linux dev host, but they use the same verified `Download` API.