### PR TITLE
lint: --pull=always on local docker Lint tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -253,6 +253,7 @@
             "args": [
                 "run",
                 "--rm",
+                "--pull=always",
                 "--volume=${workspaceFolder}:/check",
                 "--workdir=/check",
                 "mstruebing/editorconfig-checker:latest"
@@ -270,6 +271,7 @@
             "args": [
                 "run",
                 "--rm",
+                "--pull=always",
                 "--volume=${workspaceFolder}:/repo",
                 "--workdir=/repo",
                 "rhysd/actionlint:latest",
@@ -288,6 +290,7 @@
             "args": [
                 "run",
                 "--rm",
+                "--pull=always",
                 "--volume=${workspaceFolder}:/workdir",
                 "--workdir=/workdir",
                 "davidanson/markdownlint-cli2:latest",
@@ -306,6 +309,7 @@
             "args": [
                 "run",
                 "--rm",
+                "--pull=always",
                 "--volume=${workspaceFolder}:/workdir",
                 "--workdir=/workdir",
                 "ghcr.io/streetsidesoftware/cspell:latest",


### PR DESCRIPTION
Applies the ProjectTemplate #284 standard: local docker `Lint:` tasks get `--pull=always` so they use the current `:latest` image. CI unaffected.

Note: the every-tier Dependabot auto-merge policy tracked in #799 is already in place on develop - the merge-bot has no `version-update:semver-major` guard (and no metadata step), and WORKFLOW.md (§169/§398/S12) + AGENTS.md already document every-tier. Closing #799 separately.