### PR TITLE
Keep a detected unrepairable DTS reported as RepairFailed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,7 +8,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
   - Repair non-monotonic DTS muxer warnings losslessly instead of failing repair permanently.
     - `ffmpeg -f null` can exit `0` yet emit `Application provided invalid, non monotonically increasing dts to muxer` for files that may decode and play correctly.
     - The previous "any stderr means failure" rule promoted this muxer-interleaving artifact to a hard `VerifyFailed`/`RepairFailed`, and a re-encode could not fix it because Matroska stores no DTS and ffmpeg re-derives a non-monotonic timeline on read.
-    - Verify now classifies the decode diagnostics deterministically as clean, a benign timestamp-only failure, or a decode error; the timestamp-only failure is correctable rather than permanent, and everything else fails (fail-closed, so an unrecognized diagnostic fails as a decode error).
+    - Verify now classifies the decode diagnostics deterministically as clean, a timestamp-only failure, or a decode error; a timestamp-only failure is repaired losslessly when the break is demux-visible and otherwise stays reported, and everything else fails (fail-closed, so an unrecognized diagnostic fails as a decode error).
     - The classification streams the output line by line, so memory stays bounded even when a file emits a warning per packet ([#827](https://github.com/ptr727/PlexCleaner/issues/827)).
   - Added a lossless timestamp repair as the first repair tier.
     - When verification detects a demux-visible non-monotonic DTS, the audio packet timestamps are rewritten to be strictly monotonic using the `setts` bitstream filter with a stream copy (no re-encode), then re-verified.

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -2174,7 +2174,7 @@ public class ProcessFile
                 _sidecarFile.State &= ~SidecarFile.StatesType.RepairFailed;
                 return Refresh(false);
             case VerifyResult.TimestampOnly:
-                // Benign non-monotonic DTS, clean losslessly when demux-visible
+                // Detected non-monotonic DTS, repair losslessly when demux-visible, else stays reported
                 return RepairTimestampsAndSetState(ref modified);
             case VerifyResult.DecodeError:
                 // Genuine decode corruption, not repairable here, leave the state unchanged
@@ -2184,65 +2184,45 @@ public class ProcessFile
         }
     }
 
-    private enum TimestampRepair
-    {
-        // No demux-visible break, the muxer warning is a post-decode artifact with no defect to repair
-        NotApplicable,
-
-        // Timestamps rewritten losslessly
-        Repaired,
-
-        // A demux-visible break, but the lossless repair could not complete
-        Failed,
-    }
-
     private bool RepairTimestampsAndSetState(ref bool modified)
     {
-        switch (TryLosslessTimestampRepair())
+        // A detected non-monotonic DTS is a failure, repair it losslessly when the break is demux-visible
+        if (TryLosslessTimestampRepair())
         {
-            case TimestampRepair.Repaired:
-                _sidecarFile.State |= SidecarFile.StatesType.Verified;
-                _sidecarFile.State &= ~SidecarFile.StatesType.VerifyFailed;
-                _sidecarFile.State |= SidecarFile.StatesType.Repaired;
-                _sidecarFile.State &= ~SidecarFile.StatesType.RepairFailed;
-                modified = true;
-                return Refresh(true);
-            case TimestampRepair.NotApplicable:
-                // No demux-visible defect, the media is benign, mark verified without a rewrite
-                _sidecarFile.State |= SidecarFile.StatesType.Verified;
-                _sidecarFile.State &= ~SidecarFile.StatesType.VerifyFailed;
-                _sidecarFile.State &= ~SidecarFile.StatesType.RepairFailed;
-                return Refresh(false);
-            case TimestampRepair.Failed:
-                // Do not touch state on cancellation, the caller retries next run
-                if (Program.IsCancelled())
-                {
-                    return false;
-                }
-                // The lossless repair failed, leave it as a repair failure
-                _sidecarFile.State |= SidecarFile.StatesType.VerifyFailed;
-                _sidecarFile.State &= ~SidecarFile.StatesType.Verified;
-                _sidecarFile.State |= SidecarFile.StatesType.RepairFailed;
-                _sidecarFile.State &= ~SidecarFile.StatesType.Repaired;
-                _ = Refresh(false);
-                return false;
-            default:
-                throw new NotImplementedException();
+            _sidecarFile.State |= SidecarFile.StatesType.Verified;
+            _sidecarFile.State &= ~SidecarFile.StatesType.VerifyFailed;
+            _sidecarFile.State |= SidecarFile.StatesType.Repaired;
+            _sidecarFile.State &= ~SidecarFile.StatesType.RepairFailed;
+            modified = true;
+            return Refresh(true);
         }
+
+        // Do not touch state on cancellation, the caller retries next run
+        if (Program.IsCancelled())
+        {
+            return false;
+        }
+
+        // A detected DTS we could not repair stays reported as a failure, a detected issue is not cleared
+        _sidecarFile.State |= SidecarFile.StatesType.VerifyFailed;
+        _sidecarFile.State &= ~SidecarFile.StatesType.Verified;
+        _sidecarFile.State |= SidecarFile.StatesType.RepairFailed;
+        _sidecarFile.State &= ~SidecarFile.StatesType.Repaired;
+        _ = Refresh(false);
+        return false;
     }
 
-    private TimestampRepair TryLosslessTimestampRepair()
+    private bool TryLosslessTimestampRepair()
     {
-        // Could not analyze packets, treat as a repair failure rather than assume benign
-        if (!GetPacketAnalysis(false, out _, out DtsInfo? dtsInfo) || dtsInfo == null)
+        // Only a demux-visible non-monotonic DTS can be rewritten losslessly, a post-decode-only break has
+        // no demux target and stays a reported failure, an analysis failure is treated as unrepaired too
+        if (
+            !GetPacketAnalysis(false, out _, out DtsInfo? dtsInfo)
+            || dtsInfo == null
+            || !dtsInfo.HasNonMonotonicDts
+        )
         {
-            return TimestampRepair.Failed;
-        }
-
-        // No demux-visible break, a post-decode-only DTS is left to verify reclassification
-        if (!dtsInfo.HasNonMonotonicDts)
-        {
-            return TimestampRepair.NotApplicable;
+            return false;
         }
 
         // Rewrite timestamps losslessly to a temp file
@@ -2254,7 +2234,7 @@ public class ProcessFile
         if (!Tools.FfMpeg.SetTimestamps(FileInfo.FullName, tempName))
         {
             File.Delete(tempName);
-            return TimestampRepair.Failed;
+            return false;
         }
 
         // Reject unless the payload is byte-identical and the result verifies clean
@@ -2264,13 +2244,13 @@ public class ProcessFile
         )
         {
             File.Delete(tempName);
-            return TimestampRepair.Failed;
+            return false;
         }
 
         // Replace the original with the repaired file
         File.Move(tempName, FileInfo.FullName, true);
         Log.Information("Timestamp repair succeeded : {FileName}", FileInfo.FullName);
-        return TimestampRepair.Repaired;
+        return true;
     }
 
     private static bool TimestampRepairRegressionGate(string original, string repaired) =>

--- a/PlexCleaner/VerifyClassifier.cs
+++ b/PlexCleaner/VerifyClassifier.cs
@@ -41,7 +41,7 @@ internal static class VerifyClassifier
                 return;
             }
 
-            // A benign muxer timestamp warning does not by itself fail verify
+            // A muxer timestamp warning classifies as TimestampOnly, distinct from a decode error
             if (
                 s_timestampSignatures.Any(sig =>
                     line.Contains(sig, StringComparison.OrdinalIgnoreCase)

--- a/Plugins/DtsTimestampRepair/DtsTimestampRepairPlugin.cs
+++ b/Plugins/DtsTimestampRepair/DtsTimestampRepairPlugin.cs
@@ -81,8 +81,8 @@ public sealed class DtsTimestampRepairPlugin : IProcessPlugin
             return true;
         }
 
-        // Re-verify and losslessly repair a demux-visible DTS, clearing RepairFailed only on success, an
-        // unrepairable DTS stays reported, RepairTimestamps keeps the sidecar in sync
+        // Re-verify and losslessly repair a demux-visible DTS. Clear RepairFailed only on success.
+        // An unrepairable DTS stays reported. RepairTimestamps keeps the sidecar in sync.
         bool modified = false;
         return processFile.RepairTimestamps(ref modified);
     }

--- a/Plugins/DtsTimestampRepair/DtsTimestampRepairPlugin.cs
+++ b/Plugins/DtsTimestampRepair/DtsTimestampRepairPlugin.cs
@@ -2,10 +2,9 @@ using Serilog;
 
 namespace PlexCleaner.Plugins.DtsTimestampRepair;
 
-// Retroactively repair files that an older PlexCleaner version marked RepairFailed because verify
-// wrongly rejected a benign non-monotonic-DTS muxer warning. Re-verifies each RepairFailed file, clears
-// the flag when the only problem is timestamps, and losslessly rewrites the timestamps (setts) when the
-// DTS is demux-visible. Reuses PlexCleaner.ProcessFile.RepairTimestamps.
+// Revisit files a previous run marked RepairFailed and losslessly repair a demux-visible non-monotonic
+// DTS with the setts filter, clearing the flag only on a successful repair or a clean re-verify. A
+// detected DTS that cannot be repaired stays RepairFailed. Reuses PlexCleaner.ProcessFile.RepairTimestamps.
 public sealed class DtsTimestampRepairPlugin : IProcessPlugin
 {
     private ILogger _logger = Log.Logger;
@@ -82,8 +81,8 @@ public sealed class DtsTimestampRepairPlugin : IProcessPlugin
             return true;
         }
 
-        // Re-verify and clear the RepairFailed flag when the failure was a benign timestamp issue,
-        // losslessly repairing the timestamps when possible, RepairTimestamps keeps the sidecar in sync
+        // Re-verify and losslessly repair a demux-visible DTS, clearing RepairFailed only on success, an
+        // unrepairable DTS stays reported, RepairTimestamps keeps the sidecar in sync
         bool modified = false;
         return processFile.RepairTimestamps(ref modified);
     }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 
 - Repair non-monotonic DTS losslessly with the `setts` bitstream filter instead of failing repair permanently; a non-monotonic DTS is a correctable verify failure, not decode corruption.
 - Switched closed caption detection to `ffprobe -analyze_frames`, and consolidated the bitrate and DTS packet analyses into a single packet pass.
-- Added the `DtsTimestampRepair` example plugin that revisits files a previous version marked `RepairFailed` and clears or losslessly repairs benign timestamp failures.
+- Added the `DtsTimestampRepair` example plugin that revisits files a previous version marked `RepairFailed` and losslessly repairs a demux-visible non-monotonic DTS, clearing the flag on success.
 
 **Version: 3.20**:
 
@@ -863,7 +863,7 @@ public interface IProcessPlugin
 `Initialize` receives an `IPluginHost` with the deterministic `PluginApiVersion`, the application and OS versions, and a `Serilog.ILogger` to log through. `ProcessFile` reuses the public processing API, for example `new ProcessFile(fileName)` then `RepairMatroskaStructure(...)`. Two examples are included:
 
 - [`MatroskaHeaderCleanup`](./Plugins/MatroskaHeaderCleanup/) re-checks and repairs the Matroska seek-index structure on already-verified files.
-- [`DtsTimestampRepair`](./Plugins/DtsTimestampRepair/) revisits files that an older version marked `RepairFailed`, re-verifies them, clears the flag when the only problem was a benign non-monotonic DTS, and losslessly repairs the timestamps (`setts`) when the DTS is demux-visible.
+- [`DtsTimestampRepair`](./Plugins/DtsTimestampRepair/) revisits files that an older version marked `RepairFailed`, re-verifies them, and losslessly repairs the timestamps (`setts`) when the non-monotonic DTS is demux-visible, clearing the flag on success; a detected DTS it cannot repair stays reported.
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 
 **Summary:**
 
-- Repair non-monotonic DTS losslessly with the `setts` bitstream filter instead of failing repair permanently; a non-monotonic DTS is a correctable verify failure, not decode corruption.
+- Treat a non-monotonic DTS as a verify failure, not decode corruption. Repair it losslessly with the `setts` bitstream filter when the break is demux-visible, otherwise keep it reported as a failure.
 - Switched closed caption detection to `ffprobe -analyze_frames`, and consolidated the bitrate and DTS packet analyses into a single packet pass.
 - Added the `DtsTimestampRepair` example plugin that revisits files a previous version marked `RepairFailed` and losslessly repairs a demux-visible non-monotonic DTS, clearing the flag on success.
 


### PR DESCRIPTION
Follow-up to [#833](https://github.com/ptr727/PlexCleaner/pull/833).

A non-monotonic DTS that verify detects but the lossless `setts` repair cannot fix - a post-decode-only break with no demux-visible target, an analysis failure, or a rewrite that fails the byte-identical / clean re-verify gate - was marked `Verified`, silently clearing a detected issue.

It is now kept reported as `RepairFailed`. Only a successful lossless repair or a genuinely `Clean` re-verify clears the flag, consistent with the re-encode path (which already requires `Clean`). A detected issue is never cleared just because it cannot be repaired.

- Removed the `NotApplicable -> Verified` outcome; `RepairTimestampsAndSetState` now maps any unrepaired timestamp result to `VerifyFailed`/`RepairFailed`, with the cancellation guard preserved.
- Dropped the "benign" framing from the code, plugin, README, and HISTORY.

207 unit tests pass; build, format, markdownlint, cspell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)