### PR TITLE
Ignore ffmpeg repeat markers and log unique verify errors

### DIFF
--- a/PlexCleaner/FfMpegTool.cs
+++ b/PlexCleaner/FfMpegTool.cs
@@ -179,8 +179,8 @@ public partial class FfMpeg
             }
             if (verifyResult == VerifyResult.DecodeError)
             {
-                // A silent non-zero exit has no error line, omit the empty field rather than logging blank
-                string error = CleanForLog(classifier.FirstError ?? string.Empty);
+                // Log the unique error lines, a silent non-zero exit has none so omit the empty field
+                string error = CleanForLog(string.Join(" | ", classifier.Errors));
                 if (string.IsNullOrEmpty(error))
                 {
                     Log.Error(

--- a/PlexCleaner/VerifyClassifier.cs
+++ b/PlexCleaner/VerifyClassifier.cs
@@ -10,8 +10,9 @@ internal static partial class VerifyClassifier
         "non monotonically increasing dts to muxer",
     ];
 
-    // Mask pointer addresses and numbers so error lines that differ only by those collapse to one key
-    [GeneratedRegex(@"0x[0-9a-fA-F]+|\d+")]
+    // Mask pointer addresses and standalone numbers so lines differing only by those collapse to one
+    // key; word boundaries keep digits inside identifiers like h264 or mpeg2 so distinct codecs stay apart
+    [GeneratedRegex(@"0x[0-9a-fA-F]+|\b[0-9]+\b")]
     private static partial Regex VariableDataRegex();
 
     private static string NormalizeKey(string line) => VariableDataRegex().Replace(line, "*");

--- a/PlexCleaner/VerifyClassifier.cs
+++ b/PlexCleaner/VerifyClassifier.cs
@@ -1,12 +1,20 @@
+using System.Text.RegularExpressions;
+
 namespace PlexCleaner;
 
-internal static class VerifyClassifier
+internal static partial class VerifyClassifier
 {
     // Non-monotonic-DTS muxer warnings emitted by the -f null muxer at error loglevel
     private static readonly List<string> s_timestampSignatures =
     [
         "non monotonically increasing dts to muxer",
     ];
+
+    // Mask pointer addresses and numbers so error lines that differ only by those collapse to one key
+    [GeneratedRegex(@"0x[0-9a-fA-F]+|\d+")]
+    private static partial Regex VariableDataRegex();
+
+    private static string NormalizeKey(string line) => VariableDataRegex().Replace(line, "*");
 
     public static VerifyResult Classify(string stderr)
     {
@@ -23,13 +31,21 @@ internal static class VerifyClassifier
 
     public sealed class Accumulator
     {
-        private bool _decodeError;
+        // Backstop against a pathological file with many distinct error types
+        private const int MaxErrorLines = 50;
+
         private bool _timestamp;
 
-        public string? FirstError { get; private set; }
+        // Unique decode-error lines kept for the failure log, deduped by normalized key, insertion ordered
+        private readonly HashSet<string> _errorKeys = [];
+        private readonly List<string> _errors = [];
+
+        public bool HasErrors => _errors.Count > 0;
+
+        public IReadOnlyList<string> Errors => _errors;
 
         public VerifyResult Result =>
-            _decodeError ? VerifyResult.DecodeError
+            HasErrors ? VerifyResult.DecodeError
             : _timestamp ? VerifyResult.TimestampOnly
             : VerifyResult.Clean;
 
@@ -37,6 +53,13 @@ internal static class VerifyClassifier
         {
             line = line.Trim();
             if (line.Length == 0)
+            {
+                return;
+            }
+
+            // ffmpeg collapses consecutive identical messages into this marker, it repeats the previous
+            // line's classification which is already recorded, so ignore it
+            if (line.StartsWith("Last message repeated", StringComparison.Ordinal))
             {
                 return;
             }
@@ -52,9 +75,12 @@ internal static class VerifyClassifier
                 return;
             }
 
-            // Anything else at error loglevel is treated as decode corruption, fail closed
-            _decodeError = true;
-            FirstError ??= line;
+            // Any other line at error loglevel is a decode error, fail closed; keep the unique lines for
+            // the log, deduped by normalized key and capped as a backstop
+            if (_errors.Count < MaxErrorLines && _errorKeys.Add(NormalizeKey(line)))
+            {
+                _errors.Add(line);
+            }
         }
     }
 }

--- a/PlexCleanerTests/VerifyClassifierTests.cs
+++ b/PlexCleanerTests/VerifyClassifierTests.cs
@@ -74,4 +74,15 @@ public class VerifyClassifierTests
             .Be("[pgssub @ 0x5f38] Unknown subtitle segment type 0x78, length 55981");
         _ = accumulator.Errors[1].Should().Be("[aac @ 0x62] Prediction is not allowed in AAC-LC");
     }
+
+    [Fact]
+    public void Accumulator_DifferentCodecSameMessage_NotDeduped()
+    {
+        // Digits inside a codec identifier must not be masked, so distinct codecs stay separate
+        VerifyClassifier.Accumulator accumulator = new();
+        accumulator.Add("[h264 @ 0x1] error while decoding MB 3 4");
+        accumulator.Add("[h265 @ 0x2] error while decoding MB 3 4");
+
+        _ = accumulator.Errors.Should().HaveCount(2);
+    }
 }

--- a/PlexCleanerTests/VerifyClassifierTests.cs
+++ b/PlexCleanerTests/VerifyClassifierTests.cs
@@ -22,20 +22,27 @@ public class VerifyClassifierTests
         _ = VerifyClassifier.Classify(stderr).Should().Be(VerifyResult.TimestampOnly);
     }
 
+    [Fact]
+    public void Classify_DtsWarningFollowedByRepeatMarker_ReturnsTimestampOnly()
+    {
+        // ffmpeg collapses consecutive identical DTS warnings, the repeat marker must not fail the file
+        string stderr =
+            "[null @ 0x1] Application provided invalid, non monotonically increasing dts to muxer in stream 1: 8 >= 8\n"
+            + "    Last message repeated 1 times\n";
+        _ = VerifyClassifier.Classify(stderr).Should().Be(VerifyResult.TimestampOnly);
+    }
+
     [Theory]
     [InlineData("[matroska @ 0x1] Invalid data found when processing input")]
     [InlineData("[h264 @ 0x1] error while decoding MB 10 20")]
     [InlineData("[NULL @ 0x1] Invalid NAL unit size (-1148261185 > 8772).")]
-    [InlineData("[h264 @ 0x1] mmco: unref short failure")]
-    [InlineData("[aac @ 0x1] env_facs_q 255 is invalid")]
-    [InlineData("[matroska,webm @ 0x1] Length 7 indicated by an EBML number exceeds max length 4.")]
-    public void Classify_DecodeSignature_ReturnsDecodeError(string stderr) =>
+    [InlineData("[truehd @ 0x1] quant_step_size larger than huff_lsbs")]
+    public void Classify_DecodeError_ReturnsDecodeError(string stderr) =>
         VerifyClassifier.Classify(stderr).Should().Be(VerifyResult.DecodeError);
 
     [Fact]
     public void Classify_DecodeErrorMixedWithDtsWarning_ReturnsDecodeError()
     {
-        // A decode error co-occurring with benign DTS warnings must still fail
         string stderr =
             "[null @ 0x1] Application provided invalid, non monotonically increasing dts to muxer in stream 1: 8 >= 8\n"
             + "[h264 @ 0x1] error while decoding MB 3 4\n";
@@ -51,19 +58,20 @@ public class VerifyClassifierTests
             .Be(VerifyResult.DecodeError);
 
     [Fact]
-    public void Accumulator_StreamedLines_ClassifiesAndKeepsFirstError()
+    public void Accumulator_RepeatedErrorType_DedupedToUniqueLines()
     {
-        // The accumulator sees lines one at a time without buffering the whole stderr
+        // Lines differing only by pointer address or numbers collapse to one entry, distinct types do not
         VerifyClassifier.Accumulator accumulator = new();
-        accumulator.Add(
-            "[null @ 0x1] Application provided invalid, non monotonically increasing dts to muxer in stream 1: 8 >= 8"
-        );
-        _ = accumulator.Result.Should().Be(VerifyResult.TimestampOnly);
-
-        accumulator.Add("[h264 @ 0x1] error while decoding MB 3 4");
-        accumulator.Add("[h264 @ 0x1] Invalid data found");
+        accumulator.Add("[pgssub @ 0x5f38] Unknown subtitle segment type 0x78, length 55981");
+        accumulator.Add("[pgssub @ 0x5f38] Unknown subtitle segment type 0x93, length 2183");
+        accumulator.Add("[aac @ 0x62] Prediction is not allowed in AAC-LC");
 
         _ = accumulator.Result.Should().Be(VerifyResult.DecodeError);
-        _ = accumulator.FirstError.Should().Be("[h264 @ 0x1] error while decoding MB 3 4");
+        _ = accumulator.Errors.Should().HaveCount(2);
+        _ = accumulator
+            .Errors[0]
+            .Should()
+            .Be("[pgssub @ 0x5f38] Unknown subtitle segment type 0x78, length 55981");
+        _ = accumulator.Errors[1].Should().Be("[aac @ 0x62] Prediction is not allowed in AAC-LC");
     }
 }


### PR DESCRIPTION
Follow-up to [#833](https://github.com/ptr727/PlexCleaner/pull/833) / [#834](https://github.com/ptr727/PlexCleaner/pull/834).

**Correctness fix (primary).** ffmpeg collapses consecutive identical stderr messages into `Last message repeated N times`. The verify classifier didn't recognize that continuation line and fail-closed it to `DecodeError`. A duplicate-DTS file - the *dominant* benign case in #827, where the shared DTS value repeats and triggers the marker - was therefore misclassified as a decode error and routed to the ineffective re-encode path instead of the lossless `setts` repair. Verified on a real duplicate-DTS file (GBBO S13E05): before, its entire stderr is one DTS warning plus `Last message repeated 1 times`; now it classifies `TimestampOnly` and repairs losslessly.

**Diagnostics.** The `DecodeError` log captured only the first genuine error line. It now collects the *unique* error lines (deduped by a normalized key that masks pointer addresses and numbers, capped at 50 as a backstop) and logs them together. Tested against the corruption corpus: e.g. Indiana Jones now logs both `[hevc] PPS changed between slices` and `[truehd] quant_step_size larger than huff_lsbs` (the real error the single-line capture dropped), with the repeated `PPS` lines collapsed to one. Bounded memory - the full stderr is never buffered.

206 unit tests pass (added coverage for the repeat-marker fix and the dedup); build, format, markdownlint, cspell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)