### PR TITLE
Produce full output for the setts timestamp repair

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ Anti-pattern: don't keep flipping the code on the same style point. Flip the rul
 - **Brownfield analyzer relaxations.** `Directory.Build.props` sets strict analysis; because this is a pre-existing console app, a specific set of analyzer rules are relaxed to suggestion in [`.editorconfig`](./.editorconfig), each documented inline. Prefer fixing new violations over adding relaxations.
 - **Spell check.** The cspell word list and path exclusions live in [`cspell.json`](./cspell.json), the single source shared by the editor and CI. Do not keep a parallel word list in the `.code-workspace` file.
 - **Run CI CLI tooling via Docker.** The linters CI uses (actionlint, markdownlint-cli2, shellcheck, cspell, etc.) need not be installed on the host - run them from their official images (e.g. `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint`) to reproduce a CI check locally before pushing.
-- **Release notes.** Keep a short summary in [`README.md`](./README.md) and the full history in [`HISTORY.md`](./HISTORY.md); update both when cutting a release.
+- **Release notes.** Keep a short summary in [`README.md`](./README.md) and the full history in [`HISTORY.md`](./HISTORY.md); update both when cutting a release. `README.md` carries the summary for the **current version only** - when bumping the version, replace the previous version's summary rather than appending; prior versions live in `HISTORY.md`.
 
 ## Communicating with the User
 

--- a/PlexCleaner/FfMpegTool.cs
+++ b/PlexCleaner/FfMpegTool.cs
@@ -363,9 +363,11 @@ public partial class FfMpeg
             File.Delete(outputName);
 
             // Build command line, the escaped comma separates the setts option arguments
+            // No TestSnippets: this lossless stream-copy repair must produce the full file so the
+            // byte-identical gate and re-verify validate the whole file, not an unrepresentative snippet
             Command command = GetBuilder()
                 .GlobalOptions(options => options.Default())
-                .InputOptions(options => options.Default().TestSnippets().InputFile(inputName))
+                .InputOptions(options => options.Default().InputFile(inputName))
                 .OutputOptions(options =>
                     options
                         .MapAllCodecCopy()

--- a/README.md
+++ b/README.md
@@ -27,20 +27,9 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 
 **Summary:**
 
-- Treat a non-monotonic DTS as a verify failure, not decode corruption. Repair it losslessly with the `setts` bitstream filter when the break is demux-visible, otherwise keep it reported as a failure.
+- Treat non-monotonic DTS errors as a verify failure, and attempt to repair it losslessly with the `setts` bitstream filter.
 - Switched closed caption detection to `ffprobe -analyze_frames`, and consolidated the bitrate and DTS packet analyses into a single packet pass.
-- Added the `DtsTimestampRepair` example plugin that revisits files a previous version marked `RepairFailed` and losslessly repairs a demux-visible non-monotonic DTS, clearing the flag on success.
-
-**Version: 3.20**:
-
-**Summary:**
-
-- Reworked logging: added `--loglevel` (`Verbose` ... `Fatal`) to select the log level, `--logclear` (the log file now appends by default), and `--logelevate` to opt into raising a file's level to `Information` after a warning or error. `--logwarning` and `--logappend` are deprecated. Low-level tool and per-track chatter is now logged at `Debug`/`Verbose`.
-- Always log the end-of-run summary, and handle stop signals (`docker stop`, `Ctrl+C`) so processing stops gracefully and the summary and exit code are logged before exit.
-- Normalize multiple or redundant `Default` track flags instead of only warning about them.
-- Fixed an `idet` interlace-detection defect where ffmpeg emitting its statistics more than once could cause the counts to parse incorrectly and detection to fail; also improved detection reporting (detection source and a self-describing reason).
-- Added a `custom` command that runs a user-provided plugin assembly over the media files for bespoke re-processing or repair, see [Custom Plugins](#custom-plugins).
-- Fixed closed caption removal for H.265/HEVC video that was incorrectly reported as an unsupported format (HDR10 and HDR10+ HEVC content remains guarded).
+- Added the `DtsTimestampRepair` example plugin that attempts non-monotonic DTS repairs on `RepairFailed` files.
 
 See [Release History](./HISTORY.md) for complete release notes and older versions.
 


### PR DESCRIPTION
Follow-up to [#835](https://github.com/ptr727/PlexCleaner/pull/835). Found by comparing a 3.21 regression run against the 3.20 baseline.

`SetTimestamps` (the lossless `setts` repair) honored `--testsnippets`, so in test mode it wrote a 30-second snippet. The byte-identical regression gate then compared the **full** source hash against the **snippet** output hash, failed, and marked a genuinely repairable file `RepairFailed` (e.g. Ghosted S01E04, which repairs correctly in production). More importantly, a snippet can not represent the whole file - some files pass on a snippet and fail on the full file - so the repair's gate and re-verify must cover the **entire** output.

`setts` is a fast stream-copy, so full output in test mode costs seconds. Unlike a re-encode, there is no reason to snippet it, and doing so undermines the validation. Drop `.TestSnippets()` from `SetTimestamps`.

Also included:
- README release-notes edit: the summary now carries the current version only (the v3.20 section moved out; it lives in HISTORY).
- AGENTS.md: note that README carries only the current version's summary.

207 tests pass; build, format, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)