### PR TITLE
Fix DTS repair escalation and idet parse regressions

### DIFF
--- a/PlexCleaner/FfMpegIdetInfo.cs
+++ b/PlexCleaner/FfMpegIdetInfo.cs
@@ -105,43 +105,56 @@ public partial class FfMpegIdetInfo
         // [out#0/null @ 000001c11d401040] video:32843KiB audio:0KiB subtitle:0KiB other streams:0KiB global headers:0KiB muxing overhead: unknown
         // frame=76434 fps=1114 q=-0.0 Lsize=N/A time=00:42:30.68 bitrate=N/A speed=37.2x
 
-        // Match (regex construction uses \n for new line)
-        // idet can emit its stats more than once (an early empty pass before the final counts),
-        // so match every triple and use the last, which holds the final cumulative counts
-        MatchCollection matches = IdetRegex()
-            .Matches(text.Replace("\r\n", "\n", StringComparison.Ordinal));
-        if (matches.Count == 0)
+        // Match each of the three stat lines independently and take the last of each. idet emits its
+        // stats more than once (an early empty pass before the final cumulative counts), and ffmpeg can
+        // interleave other stderr lines between them (e.g. -f null muxer "non monotonically increasing
+        // dts" warnings when the source has non-monotonic DTS), so a single contiguous three-line match
+        // is unreliable; the last of each line is the final cumulative value
+        string normalized = text.Replace("\r\n", "\n", StringComparison.Ordinal);
+        Match? repeated = LastMatch(RepeatedFieldsRegex(), normalized);
+        Match? single = LastMatch(SingleFrameRegex(), normalized);
+        Match? multi = LastMatch(MultiFrameRegex(), normalized);
+        if (repeated == null || single == null || multi == null)
         {
-            Log.Error("Failed to parse idet output");
+            // Log the output that failed to parse so the failure is diagnosable, joined to one line
+            Log.Error("Failed to parse idet output : {Output}", text.ReplaceLineEndings(" | "));
             return false;
         }
-        Match match = matches[^1];
 
         // Get the frame counts
-        RepeatedFields.Neither = ParseGroupInt(match, "repeated_neither");
-        RepeatedFields.Top = ParseGroupInt(match, "repeated_top");
-        RepeatedFields.Bottom = ParseGroupInt(match, "repeated_bottom");
+        RepeatedFields.Neither = ParseGroupInt(repeated, "repeated_neither");
+        RepeatedFields.Top = ParseGroupInt(repeated, "repeated_top");
+        RepeatedFields.Bottom = ParseGroupInt(repeated, "repeated_bottom");
 
-        SingleFrame.Tff = ParseGroupInt(match, "single_tff");
-        SingleFrame.Bff = ParseGroupInt(match, "single_bff");
-        SingleFrame.Progressive = ParseGroupInt(match, "single_prog");
-        SingleFrame.Undetermined = ParseGroupInt(match, "single_und");
+        SingleFrame.Tff = ParseGroupInt(single, "single_tff");
+        SingleFrame.Bff = ParseGroupInt(single, "single_bff");
+        SingleFrame.Progressive = ParseGroupInt(single, "single_prog");
+        SingleFrame.Undetermined = ParseGroupInt(single, "single_und");
 
-        MultiFrame.Tff = ParseGroupInt(match, "multi_tff");
-        MultiFrame.Bff = ParseGroupInt(match, "multi_bff");
-        MultiFrame.Progressive = ParseGroupInt(match, "multi_prog");
-        MultiFrame.Undetermined = ParseGroupInt(match, "multi_und");
+        MultiFrame.Tff = ParseGroupInt(multi, "multi_tff");
+        MultiFrame.Bff = ParseGroupInt(multi, "multi_bff");
+        MultiFrame.Progressive = ParseGroupInt(multi, "multi_prog");
+        MultiFrame.Undetermined = ParseGroupInt(multi, "multi_und");
         return true;
+    }
+
+    private static Match? LastMatch(Regex regex, string text)
+    {
+        MatchCollection matches = regex.Matches(text);
+        return matches.Count > 0 ? matches[^1] : null;
     }
 
     internal static int ParseGroupInt(Match match, string groupName) =>
         int.Parse(match.Groups[groupName].Value.Trim(), CultureInfo.InvariantCulture);
 
-    [GeneratedRegex(
-        $"{IdetRepeatedFields}\n{IdetSingleFrame}\n{IdetMultiFrame}",
-        RegexOptions.IgnoreCase | RegexOptions.Multiline
-    )]
-    public static partial Regex IdetRegex();
+    [GeneratedRegex(IdetRepeatedFields, RegexOptions.IgnoreCase | RegexOptions.Multiline)]
+    private static partial Regex RepeatedFieldsRegex();
+
+    [GeneratedRegex(IdetSingleFrame, RegexOptions.IgnoreCase | RegexOptions.Multiline)]
+    private static partial Regex SingleFrameRegex();
+
+    [GeneratedRegex(IdetMultiFrame, RegexOptions.IgnoreCase | RegexOptions.Multiline)]
+    private static partial Regex MultiFrameRegex();
 
     public class Repeated
     {

--- a/PlexCleaner/ProcessDriver.cs
+++ b/PlexCleaner/ProcessDriver.cs
@@ -178,8 +178,10 @@ public static class ProcessDriver
                             fileName
                         );
 
-                        // Perform the task
+                        // Perform the task, timing this file's work
+                        long startTimestamp = Stopwatch.GetTimestamp();
                         bool taskResult = taskFunc(fileName);
+                        TimeSpan taskElapsed = Stopwatch.GetElapsedTime(startTimestamp);
 
                         // Handle cancel request
                         Program.CancelToken().ThrowIfCancellationRequested();
@@ -198,9 +200,10 @@ public static class ProcessDriver
                             totalCount
                         );
                         Log.Information(
-                            "{TaskName} ({Processed:F2}%) After : {FileName}",
+                            "{TaskName} ({Processed:F2}%) Elapsed : {Elapsed:l} : After : {FileName}",
                             taskName,
                             processedPercentage,
+                            FormatDuration(taskElapsed),
                             fileName
                         );
                     }
@@ -222,7 +225,8 @@ public static class ProcessDriver
 
         // Done, force logging so the summary survives the warning floor and an interrupted run
         Log.Logger.LogOverrideContext().Information("Completed {TaskName}", taskName);
-        Log.Logger.LogOverrideContext().Information("Processing time : {Elapsed}", timer.Elapsed);
+        Log.Logger.LogOverrideContext()
+            .Information("Processing time : {Elapsed:l}", FormatDuration(timer.Elapsed));
         Log.Logger.LogOverrideContext().Information("Total files : {Count}", totalCount);
         Log.Logger.LogOverrideContext().Information("Error files : {Count}", errorCount);
 
@@ -476,6 +480,10 @@ public static class ProcessDriver
                 return true;
             }
         );
+
+    internal static string FormatDuration(TimeSpan value) =>
+        // Consistent HH:mm:ss.fff across log entries; hours from TotalHours so a multi-day run never wraps
+        $"{(int)value.TotalHours:D2}:{value.Minutes:D2}:{value.Seconds:D2}.{value.Milliseconds:D3}";
 
     private static double GetPercentage(int dividend, int divisor)
     {

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -1858,8 +1858,8 @@ public class ProcessFile
         Debug.Assert(!_sidecarFile.State.HasFlag(SidecarFile.StatesType.Verified));
         Debug.Assert(!_sidecarFile.State.HasFlag(SidecarFile.StatesType.Repaired));
 
-        // Non-monotonic DTS is a repairable failure, fix it losslessly with setts
-        // A re-encode cannot fix timestamps so it is not a fallback here
+        // Non-monotonic DTS is a repairable failure; try a lossless surgical setts repair first, then fall
+        // through to the shared remux and re-encode tiers for a video or post-decode DTS setts cannot fix
         if (_lastVerifyResult == VerifyResult.TimestampOnly)
         {
             return RepairTimestampsAndSetState(ref modified);
@@ -2074,7 +2074,20 @@ public class ProcessFile
         // https://ffmpeg.org/ffmpeg-filters.html#crop
         // -vf crop='iw-mod(iw,4)':'ih-mod(ih,4)'
 
-        // Repair to temp file, only if verify is successful replace original file
+        // Tier 1: a plain remux rewrites the container and its timestamps, clearing a demux-visible break
+        // such as a non-monotonic DTS without re-encoding; it cannot fix decode-level corruption
+        if (TryRemuxRepair())
+        {
+            Log.Information("Repair succeeded : {FileName}", FileInfo.FullName);
+            return true;
+        }
+        if (Program.IsCancelledError())
+        {
+            return false;
+        }
+
+        // Tier 2: re-encode rebuilds the streams, fixing decode corruption and timestamp breaks a remux
+        // cannot. Repair to temp file, only if verify is successful replace original file
         string tempName = Path.ChangeExtension(FileInfo.FullName, ".tmp12");
         Debug.Assert(FileInfo.FullName != tempName);
 
@@ -2148,6 +2161,34 @@ public class ProcessFile
         return true;
     }
 
+    private bool TryRemuxRepair()
+    {
+        // Remux to a temp file, only replace the original if the re-verify is clean
+        string tempName = Path.ChangeExtension(FileInfo.FullName, ".tmp11");
+        Debug.Assert(FileInfo.FullName != tempName);
+
+        Log.Information(
+            "Attempting media repair by remuxing using MkvMerge : {FileName}",
+            FileInfo.FullName
+        );
+        if (!Tools.MkvMerge.ReMuxToMkv(FileInfo.FullName, tempName))
+        {
+            File.Delete(tempName);
+            return false;
+        }
+
+        // Require a clean re-verify, a remux that still fails falls through to the re-encode tier
+        if (VerifyMediaStreams(new FileInfo(tempName)) != VerifyResult.Clean)
+        {
+            File.Delete(tempName);
+            return false;
+        }
+
+        // Verify succeeded, replace the original with the remuxed file
+        File.Move(tempName, FileInfo.FullName, true);
+        return true;
+    }
+
     public bool RepairTimestamps(ref bool modified)
     {
         // Only process Matroska files, the audio timestamp repair does not require a video stream
@@ -2186,8 +2227,10 @@ public class ProcessFile
 
     private bool RepairTimestampsAndSetState(ref bool modified)
     {
-        // A detected non-monotonic DTS is a failure, repair it losslessly when the break is demux-visible
-        if (TryLosslessTimestampRepair())
+        // Escalate through the repair tiers: a lossless surgical setts repair for a demux-visible audio
+        // DTS, then the shared remux and re-encode ladder for a video or post-decode DTS setts cannot fix.
+        // The first tier whose re-verify is clean wins
+        if (TryLosslessTimestampRepair() || RepairAndReVerify())
         {
             _sidecarFile.State |= SidecarFile.StatesType.Verified;
             _sidecarFile.State &= ~SidecarFile.StatesType.VerifyFailed;
@@ -2203,7 +2246,8 @@ public class ProcessFile
             return false;
         }
 
-        // A detected DTS we could not repair stays reported as a failure, a detected issue is not cleared
+        // No tier could repair the detected DTS, it stays reported as a failure, a detected issue is
+        // not cleared
         _sidecarFile.State |= SidecarFile.StatesType.VerifyFailed;
         _sidecarFile.State &= ~SidecarFile.StatesType.Verified;
         _sidecarFile.State |= SidecarFile.StatesType.RepairFailed;

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -1186,7 +1186,7 @@ public class ProcessFile
         // Count the frame types using the idet filter
         if (!GetIdetInfo(out idetInfo) || idetInfo == null)
         {
-            // Error
+            // Error, an idet execution or parse failure is unexpected, abort the file so the bug surfaces
             return false;
         }
 

--- a/PlexCleanerTests/FfMpegIdetParsingTests.cs
+++ b/PlexCleanerTests/FfMpegIdetParsingTests.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 using AwesomeAssertions;
 using PlexCleaner;
 using PlexCleanerTests;
@@ -86,51 +85,44 @@ public class FfMpegIdetParsingTests
                     },
                 }
             },
+            {
+                // ffmpeg interleaves other stderr lines between the idet stats; on a source with
+                // non-monotonic DTS the -f null muxer emits "non monotonically increasing dts" warnings
+                // between the three lines (the VC1 regression). The three lines must parse independently
+                new string(
+                    """
+                    [Parsed_idet_0 @ 0x7ec7fc004280] Repeated Fields: Neither:139809 Top:     2 Bottom:     0
+                    [null @ 0x5a4c] Application provided invalid, non monotonically increasing dts to muxer in stream 0: 42 >= 42
+                    [Parsed_idet_0 @ 0x7ec7fc004280] Single frame detection: TFF:   333 BFF:   259 Progressive:138387 Undetermined:   832
+                    [null @ 0x5a4c] Application provided invalid, non monotonically increasing dts to muxer in stream 0: 43 >= 43
+                    [Parsed_idet_0 @ 0x7ec7fc004280] Multi frame detection: TFF:     4 BFF:    44 Progressive:139709 Undetermined:    54
+                    """
+                ),
+                new FfMpegIdetInfo
+                {
+                    RepeatedFields = new FfMpegIdetInfo.Repeated
+                    {
+                        Neither = 139809,
+                        Top = 2,
+                        Bottom = 0,
+                    },
+                    SingleFrame = new FfMpegIdetInfo.Frames
+                    {
+                        Tff = 333,
+                        Bff = 259,
+                        Progressive = 138387,
+                        Undetermined = 832,
+                    },
+                    MultiFrame = new FfMpegIdetInfo.Frames
+                    {
+                        Tff = 4,
+                        Bff = 44,
+                        Progressive = 139709,
+                        Undetermined = 54,
+                    },
+                }
+            },
         };
-
-    [Theory]
-    [MemberData(nameof(Data))]
-    [SuppressMessage(
-        "Usage",
-        "xUnit1045:Avoid using TheoryData type arguments that might not be serializable",
-        Justification = "FfMpegIdetInfoSerializer"
-    )]
-    public void Parse_Idet_Field_Test(string text, FfMpegIdetInfo idetInfo)
-    {
-        // Follow same pattern as in FfMpegIdetInfo.Parse() : use the last triple
-        text = text.Replace("\r\n", "\n", StringComparison.Ordinal);
-        MatchCollection matches = FfMpegIdetInfo.IdetRegex().Matches(text);
-        _ = matches.Count.Should().BeGreaterThan(0);
-        Match match = matches[^1];
-
-        _ = idetInfo
-            .RepeatedFields.Neither.Should()
-            .Be(FfMpegIdetInfo.ParseGroupInt(match, "repeated_neither"));
-        _ = idetInfo
-            .RepeatedFields.Top.Should()
-            .Be(FfMpegIdetInfo.ParseGroupInt(match, "repeated_top"));
-        _ = idetInfo
-            .RepeatedFields.Bottom.Should()
-            .Be(FfMpegIdetInfo.ParseGroupInt(match, "repeated_bottom"));
-
-        _ = idetInfo.SingleFrame.Tff.Should().Be(FfMpegIdetInfo.ParseGroupInt(match, "single_tff"));
-        _ = idetInfo.SingleFrame.Bff.Should().Be(FfMpegIdetInfo.ParseGroupInt(match, "single_bff"));
-        _ = idetInfo
-            .SingleFrame.Progressive.Should()
-            .Be(FfMpegIdetInfo.ParseGroupInt(match, "single_prog"));
-        _ = idetInfo
-            .SingleFrame.Undetermined.Should()
-            .Be(FfMpegIdetInfo.ParseGroupInt(match, "single_und"));
-
-        _ = idetInfo.MultiFrame.Tff.Should().Be(FfMpegIdetInfo.ParseGroupInt(match, "multi_tff"));
-        _ = idetInfo.MultiFrame.Bff.Should().Be(FfMpegIdetInfo.ParseGroupInt(match, "multi_bff"));
-        _ = idetInfo
-            .MultiFrame.Progressive.Should()
-            .Be(FfMpegIdetInfo.ParseGroupInt(match, "multi_prog"));
-        _ = idetInfo
-            .MultiFrame.Undetermined.Should()
-            .Be(FfMpegIdetInfo.ParseGroupInt(match, "multi_und"));
-    }
 
     [Theory]
     [MemberData(nameof(Data))]

--- a/PlexCleanerTests/ProcessDriverTests.cs
+++ b/PlexCleanerTests/ProcessDriverTests.cs
@@ -1,0 +1,35 @@
+using AwesomeAssertions;
+using PlexCleaner;
+using Xunit;
+
+namespace PlexCleanerTests;
+
+public class ProcessDriverTests
+{
+    [Theory]
+    [InlineData(0, 0, 0, 0, "00:00:00.000")]
+    [InlineData(0, 0, 12, 345, "00:00:12.345")]
+    [InlineData(0, 5, 9, 7, "00:05:09.007")]
+    [InlineData(2, 3, 4, 500, "02:03:04.500")]
+    public void FormatDuration_MillisecondPrecision(
+        int hours,
+        int minutes,
+        int seconds,
+        int milliseconds,
+        string expected
+    )
+    {
+        TimeSpan value = new(0, hours, minutes, seconds, milliseconds);
+
+        _ = ProcessDriver.FormatDuration(value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void FormatDuration_MultiDay_HoursDoNotWrap()
+    {
+        // Hours come from TotalHours, so a run past 24h reads as accumulated hours, not a day rollover
+        TimeSpan value = new(1, 3, 14, 3, 512);
+
+        _ = ProcessDriver.FormatDuration(value).Should().Be("27:14:03.512");
+    }
+}


### PR DESCRIPTION
Follow-ups from the 3.20→3.21 regression diff. Two files-flip-to-failed regressions plus a diagnostics/logging improvement.

## 1. idet parse robustness (interlace detection)
`VC1 - National Lampoon's Christmas Vacation` regressed to an `Error` (`Failed to parse idet output` → `Failed to count interlaced frames`), aborting the file before it could be re-encoded.

**Root cause** (confirmed against ground-truth ffmpeg output): the parser required the three idet stat lines contiguous. The idet command uses `InputOptions.Default()`, which adds `-fflags +genpts`; on a source with non-monotonic DTS the `-f null` muxer emits `"non monotonically increasing dts to muxer"` warnings interleaved with the idet stats, and a full-file scan decodes enough packets that a warning lands between the stat lines → `matches.Count == 0`.

**Fix:** match each stat line independently and take the last of each (robust to interleaving; still selects the final counts over idet's early all-zero pass). Log the raw idet output on a parse failure. An idet failure stays a hard error that aborts the file — it is unexpected, so it should surface as a bug, not be masked. Regression test added with warnings interspersed between the stat lines.

## 2. DTS repair escalation
Six files that were `Repaired, Verified` pre-3.21 became `RepairFailed` (50 First Dates, Kill Bill, Bitrate Love Island, Running Wild, Diplo, 90 Day). A non-monotonic DTS that the lossless audio `setts` repair couldn't fix (video-stream or post-decode) was marked `RepairFailed` with no further attempt; a full re-encode fixes these and the pre-3.21 pipeline relied on it.

**Fix:** the DTS path now escalates through the standard tiers — surgical lossless `setts` → plain remux → re-encode — marking `Repaired` on the first tier whose re-verify is clean, `RepairFailed` only when all fail. Added the missing remux tier to `RepairAndReVerify` so the DTS and decode-error paths share one `surgical → remux → re-encode` ladder.

## 3. Per-file processing time
Time each file's task in the driver and log it on the `After` line (elapsed before the file name), sharing one `HH:mm:ss.fff` formatter with the run summary (hours from `TotalHours`, no multi-day wrap).

## Validation
Local build + develop image ffmpeg 8.0.1, `--parallel --testsnippets`:
- VC1 clip → `ReMuxed, ReEncoded, Verified`, no idet failure (was abort).
- Diplo (post-decode DTS) → `Repaired, Verified` via `setts→remux→re-encode` (was `RepairFailed`).

217 tests pass; build + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)