### PR TITLE
Include the Operation and File Name in Verify Failure Logs

### DIFF
--- a/PlexCleaner/FfMpegTool.cs
+++ b/PlexCleaner/FfMpegTool.cs
@@ -178,23 +178,30 @@ public partial class FfMpeg
             }
             if (verifyResult == VerifyResult.DecodeError)
             {
-                // Log the unique error lines, a silent non-zero exit has none so omit the empty field
+                // Log the unique error lines, a silent non-zero exit has none so omit the empty field.
+                // Include the operation and file name to match the tool-failure logging convention
+                // (see MediaTool.LogFailedResult); VerifyMedia streams stderr so it logs inline rather
+                // than through that helper.
                 string error = CleanForLog(string.Join(" | ", classifier.Errors));
                 if (string.IsNullOrEmpty(error))
                 {
                     Log.Error(
-                        "Failed execution of {ToolType} : ExitCode: {ExitCode}",
+                        "Failed execution of {ToolType} : {Operation:l} : ExitCode: {ExitCode} : {FileName}",
                         GetToolType(),
-                        exitCode
+                        nameof(VerifyMedia),
+                        exitCode,
+                        fileName
                     );
                 }
                 else
                 {
                     Log.Error(
-                        "Failed execution of {ToolType} : ExitCode: {ExitCode} : {Error}",
+                        "Failed execution of {ToolType} : {Operation:l} : ExitCode: {ExitCode} : {Error} : {FileName}",
                         GetToolType(),
+                        nameof(VerifyMedia),
                         exitCode,
-                        error
+                        error,
+                        fileName
                     );
                 }
             }


### PR DESCRIPTION
`FfMpegTool.VerifyMedia` streams stderr and logs its failures inline (it has the classified error
lines, not a `BufferedCommandResult`), so it never picked up the `{Operation:l}` and `{FileName}`
fields that `MediaTool.LogFailedResult` adds. Align both inline templates with that convention, using
`nameof(VerifyMedia)` for the operation and the in-scope `fileName`, so a verify decode-error failure
is attributable to its file when files process in parallel.

Surfaced by the Copilot review on the develop→main promotion (#856). The regression log parser
already accepts this fuller format, and the existing `ToolFailureLogFormatTests` cover the
`LogFailedResult` template this now matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)