### PR TITLE
Address Promotion Review Nits: Self-Contained Comment and Clearer Local

### DIFF
--- a/PlexCleaner/FfProbeTool.cs
+++ b/PlexCleaner/FfProbeTool.cs
@@ -60,16 +60,16 @@ public partial class FfProbe
             [CallerMemberName] string operation = ""
         )
         {
-            // Wrap async function in a task
-            (bool result, string error) result = GetPacketsAsync(
+            // Run the async worker synchronously; deconstruct so the tuple does not shadow the error out-param
+            (bool ok, string packetError) = GetPacketsAsync(
                     command,
                     async packet => await Task.FromResult(packetFunc(packet)),
                     operation
                 )
                 .GetAwaiter()
                 .GetResult();
-            error = result.error;
-            return result.result;
+            error = packetError;
+            return ok;
         }
 
         public async Task<(bool result, string error)> GetPacketsAsync(

--- a/RegressionTests/pyproject.toml
+++ b/RegressionTests/pyproject.toml
@@ -1,8 +1,7 @@
 # Linter-only configuration for the RegressionTests Python utilities.
 #
 # These are standalone stdlib-only scripts (no runtime dependencies), so this file carries no
-# project/build metadata - only the ruff + mypy config, mirroring the ptr727 Financial-Modeling
-# conventions. Run the tools with uv (no install needed):
+# project/build metadata - only the ruff + mypy config. Run the tools with uv (no install needed):
 #
 #   uvx ruff check .
 #   uvx ruff format --check .


### PR DESCRIPTION
Two small cleanups surfaced by the Copilot review on the develop→main promotion (#856), landed on
develop so the promotion carries them:

- `RegressionTests/pyproject.toml` — remove the "ptr727 Financial-Modeling" reference from the header
  comment; comments must be self-contained and not name other repos (AGENTS.md comment-style rule).
- `PlexCleaner/FfProbeTool.GetPackets` — deconstruct the `GetPacketsAsync` tuple into `(ok,
  packetError)` so the local no longer shadows the `out string error` parameter and the `result.result`
  access is gone. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)