### PR TITLE
Add a Synthetic Media Targeting Library for Regression Fixtures

### DIFF
--- a/RegressionTests/README.md
+++ b/RegressionTests/README.md
@@ -35,6 +35,8 @@ the repository:
   collection.
 - [`reduction-rules.example.json`](reduction-rules.example.json) -- synthetic example of the
   external rules schema.
+- [`synthetic/`](synthetic/) -- the synthetic-targeting library: build small, fully synthetic
+  fixtures that reproduce specific detections without any copyrighted media (see below).
 - [`pyproject.toml`](pyproject.toml) -- ruff and mypy configuration for the Python tooling.
 
 ## The collection
@@ -143,6 +145,54 @@ shape (the exact message template, with run- and site-varying content normalized
 ground run and from each reduced clip, and reports any source shape a clip fails to reproduce. It
 augments the reduced `catalog.json` with per-file and corpus-level coverage figures, so an
 under-covered area is always visible and it is known when a change warrants a full-collection run.
+
+## Synthetic file generation
+
+The corpus is built from real troublesome media, but many issues are *structural* (track layout,
+flags, tags, language, container, HDR, closed captions) and depend on nothing copyrighted. Those can
+be reproduced by **fully synthetic** files -- ffmpeg `lavfi` video/audio (`testsrc2`, `sine`) plus
+a targeted mux -- so a fixture can be regenerated anywhere with no media to ship. The
+[`synthetic/`](synthetic/) library is the start of this:
+
+- [`synthetic/synthesize.py`](synthetic/synthesize.py) -- generation primitives (HDR10 base, SDR
+  video, audio, subtitles) and builders that target a specific detection set, plus a small CLI.
+- [`synthetic/inject_cc_sei.py`](synthetic/inject_cc_sei.py) -- insert CEA-608 closed-caption SEI
+  into an HEVC stream (no common tool does this: ffmpeg `-a53cc` is libx264 only, libx265 drops
+  captions), preserving any HDR SEI. Importable, or a standalone CLI.
+
+Requires `ffmpeg` (with libx265) and `mkvmerge` on `PATH`. Examples:
+
+```shell
+python3 synthetic/synthesize.py hdr10-multitrack -o multitrack.mkv   # targets the track-structure set
+python3 synthetic/synthesize.py hdr10-cc -o hdr-cc.mkv               # HDR10 HEVC with closed captions
+```
+
+### Targeting methodology
+
+Pick the detections a fixture must reproduce, build a candidate, then **validate by processing it
+through the PlexCleaner image** and confirming its detections and State -- the same
+prove-equivalence idea the reduced corpus uses. Iterate the construction against the log until it
+matches the target. The builders encode what actually triggers each detection (verified this way):
+
+- **Duplicate tracks** -- the dedup keeps every *flagged* track and only dedups the rest by
+  preferred codec, so a duplicate pair must be **unflagged** and in a keep language.
+- **Track flags to be set** -- a title-implied flag (SDH / CC / Commentary / Forced) that is not
+  set as an actual flag (e.g. a subtitle titled "Forced" without the forced flag).
+- **Unwanted language tracks** -- a language not in `KeepLanguages` and not the original.
+- **Redundant Default flags** -- two or more tracks of a type flagged default.
+- **Extra video tracks** -- a second video stream.
+- **Tags** -- mkvmerge statistics tags plus a container title.
+- **HDR survives remux** -- the HDR SEI is copied through an mkvmerge remux; pairing it with a
+  removable track (above) forces the remux, so the fixture guards HDR passthrough during cleanup.
+- **Closed captions on HDR** -- an injected A53 CC SEI on an HDR (ST 2086 / 2094) HEVC stream
+  reaches the CC-on-HDR branch (which refuses removal to avoid stripping HDR metadata).
+
+### Extending the library
+
+Add a builder function that constructs the target with the primitives, register it in `TARGETS`,
+and validate it through the image. Keep everything synthetic (or publicly sourced) -- never commit
+copyrighted media or media filenames. Candidate next steps: an HDR10+ (ST 2094) SEI injector to make
+the closed-caption fixture true HDR10+, and interlaced / cover-art / container-specific targets.
 
 ## Naming conventions
 

--- a/RegressionTests/synthetic/inject_cc_sei.py
+++ b/RegressionTests/synthetic/inject_cc_sei.py
@@ -18,6 +18,7 @@ Or import ``inject(hevc_bytes) -> hevc_bytes`` from another script.
 
 import re
 import sys
+from pathlib import Path
 
 
 def build_cc_sei(cc_count: int = 1) -> bytes:
@@ -76,9 +77,7 @@ def inject(data: bytes) -> bytes:
 def main() -> None:
     if len(sys.argv) != 3:
         sys.exit("usage: inject_cc_sei.py <in.hevc> <out.hevc>")
-    data = open(sys.argv[1], "rb").read()
-    result = inject(data)
-    open(sys.argv[2], "wb").write(result)
+    Path(sys.argv[2]).write_bytes(inject(Path(sys.argv[1]).read_bytes()))
     print(f"injected CC SEI before each VCL NAL -> {sys.argv[2]}")
 
 

--- a/RegressionTests/synthetic/inject_cc_sei.py
+++ b/RegressionTests/synthetic/inject_cc_sei.py
@@ -1,0 +1,78 @@
+"""Inject CEA-608 (A53) closed-caption SEI into an HEVC Annex-B stream.
+
+No common tool embeds closed captions into HEVC - ffmpeg ``-a53cc`` is libx264 only, and libx265
+drops caption side data. This inserts a prefix-SEI NAL (type 39) carrying an A53
+``user_data_registered_itu_t_t35`` cc_data payload before every VCL NAL, leaving any existing HDR
+SEI (mastering-display / MaxCLL, and any HDR10+ ST 2094) in place. The result is an HDR + CC HEVC
+stream where ffprobe/MediaInfo report ``closed_captions=1`` and PlexCleaner reaches its
+CC-on-HDR branch (which errors rather than removing CC, to avoid stripping HDR metadata).
+
+Standalone use::
+
+    ffmpeg -i in.mkv -c:v copy -bsf:v hevc_mp4toannexb base.hevc
+    python3 inject_cc_sei.py base.hevc cc.hevc
+    mkvmerge -o out.mkv --default-duration 0:24fps cc.hevc
+
+Or import ``inject(hevc_bytes) -> hevc_bytes`` from another script.
+"""
+
+import re
+import sys
+
+
+def build_cc_sei(cc_count: int = 1) -> bytes:
+    """Build one prefix-SEI NAL (type 39) carrying an A53 CEA-608 cc_data payload.
+
+    The captions are minimal but validly structured: field-1, cc_valid, null (odd-parity) bytes -
+    enough for the decoder to attach A53 side data and set the closed-captions property. Emulation
+    prevention (``0x000003``) is applied to the RBSP.
+    """
+    triples = bytes([0xFC, 0x80, 0x80]) * cc_count
+    payload = (
+        bytes([0xB5, 0x00, 0x31, 0x47, 0x41, 0x39, 0x34, 0x03, 0xC0 | (cc_count & 0x1F), 0xFF])
+        + triples
+        + bytes([0xFF])
+    )
+    sei = bytes([0x04, len(payload)]) + payload  # payloadType=4 (t35), payloadSize
+    rbsp = sei + bytes([0x80])  # rbsp_trailing_bits
+    ep = bytearray()  # emulation prevention: 0x03 after any 00 00 {00..03}
+    zeros = 0
+    for byte in rbsp:
+        if zeros >= 2 and byte <= 3:
+            ep.append(0x03)
+            zeros = 0
+        ep.append(byte)
+        zeros = zeros + 1 if byte == 0 else 0
+    return b"\x00\x00\x00\x01" + bytes([0x4E, 0x01]) + bytes(ep)  # prefix-SEI NAL (type 39)
+
+
+def inject(data: bytes) -> bytes:
+    """Return the Annex-B HEVC stream with a CC SEI inserted before every VCL NAL."""
+    cc = build_cc_sei()
+    starts = [m.start() for m in re.finditer(b"\x00\x00\x01", data)]
+    out = bytearray()
+    for i, start in enumerate(starts):
+        payload_start = start + 3
+        if i + 1 < len(starts):
+            nxt = starts[i + 1]
+            payload_end = nxt - 1 if data[nxt - 1] == 0 else nxt
+        else:
+            payload_end = len(data)
+        nal = data[payload_start:payload_end]
+        if (nal[0] >> 1) & 0x3F < 32:  # VCL NAL -> prepend the CC SEI
+            out += cc
+        out += b"\x00\x00\x00\x01" + nal
+    return bytes(out)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        sys.exit("usage: inject_cc_sei.py <in.hevc> <out.hevc>")
+    data = open(sys.argv[1], "rb").read()
+    result = inject(data)
+    open(sys.argv[2], "wb").write(result)
+    print(f"injected CC SEI before each VCL NAL -> {sys.argv[2]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/RegressionTests/synthetic/inject_cc_sei.py
+++ b/RegressionTests/synthetic/inject_cc_sei.py
@@ -27,9 +27,11 @@ def build_cc_sei(cc_count: int = 1) -> bytes:
     enough for the decoder to attach A53 side data and set the closed-captions property. Emulation
     prevention (``0x000003``) is applied to the RBSP.
     """
+    if not 1 <= cc_count <= 31:
+        raise ValueError("cc_count must be 1..31 (the cc_count field is 5 bits)")
     triples = bytes([0xFC, 0x80, 0x80]) * cc_count
     payload = (
-        bytes([0xB5, 0x00, 0x31, 0x47, 0x41, 0x39, 0x34, 0x03, 0xC0 | (cc_count & 0x1F), 0xFF])
+        bytes([0xB5, 0x00, 0x31, 0x47, 0x41, 0x39, 0x34, 0x03, 0xC0 | cc_count, 0xFF])
         + triples
         + bytes([0xFF])
     )
@@ -49,7 +51,11 @@ def build_cc_sei(cc_count: int = 1) -> bytes:
 def inject(data: bytes) -> bytes:
     """Return the Annex-B HEVC stream with a CC SEI inserted before every VCL NAL."""
     cc = build_cc_sei()
+    # re.finditer on 00 00 01 matches both 3- and 4-byte start codes (the 4-byte code's trailing
+    # 00 00 01 is found; its leading 00 is trimmed from the previous NAL below).
     starts = [m.start() for m in re.finditer(b"\x00\x00\x01", data)]
+    if not starts:
+        raise ValueError("input is not an Annex-B HEVC stream (no start codes found)")
     out = bytearray()
     for i, start in enumerate(starts):
         payload_start = start + 3
@@ -59,6 +65,8 @@ def inject(data: bytes) -> bytes:
         else:
             payload_end = len(data)
         nal = data[payload_start:payload_end]
+        if not nal:  # consecutive start codes -> empty NAL, skip
+            continue
         if (nal[0] >> 1) & 0x3F < 32:  # VCL NAL -> prepend the CC SEI
             out += cc
         out += b"\x00\x00\x00\x01" + nal

--- a/RegressionTests/synthetic/synthesize.py
+++ b/RegressionTests/synthetic/synthesize.py
@@ -1,0 +1,161 @@
+"""Synthetic media generation for targeted regression fixtures.
+
+Build small, fully synthetic media files (ffmpeg lavfi sources - no copyrighted content) that
+target specific PlexCleaner detections, so a regression fixture can be reproduced anywhere without
+shipping media. Validate a generated file the same way the reduced corpus proves equivalence:
+process it through the PlexCleaner image and confirm its detections and State.
+
+Requires ffmpeg (with libx265) and mkvmerge on PATH.
+
+Targeting notes - the PlexCleaner behaviors these builders exploit (see the README):
+
+- Duplicate tracks: ``FindDuplicateTracks`` keeps every FLAGGED track, then dedups the rest by
+  preferred codec, so a duplicate pair must be UNFLAGGED and in a keep language.
+- Track flags to be set: a title-implied flag (SDH / CC / Commentary / Forced) that is not set as
+  an actual track flag.
+- Unwanted language: a language not in KeepLanguages and not the original language.
+- Redundant Default flags: two or more tracks of a type flagged default.
+- Extra video tracks: a second video stream.
+- Tags: mkvmerge statistics tags plus a container title.
+- HDR survives remux: the HDR SEI is copied through an mkvmerge remux (a regression guard).
+- Closed captions on HDR: an A53 CC SEI (see ``inject_cc_sei``) on an HDR (ST 2086 / 2094) HEVC
+  stream, which reaches PlexCleaner's CC-on-HDR branch.
+"""
+
+import argparse
+import subprocess
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+from inject_cc_sei import inject
+
+FFMPEG = "ffmpeg"
+MKVMERGE = "mkvmerge"
+
+# x265 params for a synthetic HDR10 (SMPTE ST 2086) stream: BT.2020 / PQ + mastering-display + MaxCLL
+HDR10_X265 = (
+    "colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc:"
+    "master-display=G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1):"
+    "max-cll=1000,400:hdr10=1:hdr10-opt=1:repeat-headers=1"
+)
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(
+        cmd,
+        check=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def gen_hdr10_base(out: Path, seconds: int = 6, width: int = 3840, height: int = 2160) -> None:
+    """Generate a synthetic HDR10 (ST 2086) HEVC clip."""
+    run(
+        [FFMPEG, "-y", "-f", "lavfi",
+         "-i", f"testsrc2=size={width}x{height}:duration={seconds}:rate=24",
+         "-c:v", "libx265", "-preset", "ultrafast", "-pix_fmt", "yuv420p10le",
+         "-x265-params", HDR10_X265, str(out)]
+    )  # fmt: skip
+
+
+def gen_sdr_video(out: Path, seconds: int = 6, width: int = 320, height: int = 240) -> None:
+    """Generate a small SDR H.264 clip, used as an extra (second) video track."""
+    run(
+        [FFMPEG, "-y", "-f", "lavfi",
+         "-i", f"testsrc2=size={width}x{height}:duration={seconds}:rate=24",
+         "-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p", str(out)]
+    )  # fmt: skip
+
+
+def gen_audio(out: Path, seconds: int = 6, freq: int = 440) -> None:
+    """Generate a synthetic AAC tone."""
+    run(
+        [FFMPEG, "-y", "-f", "lavfi", "-i", f"sine=frequency={freq}:duration={seconds}",
+         "-c:a", "aac", "-b:a", "128k", str(out)]
+    )  # fmt: skip
+
+
+def write_srt(out: Path, text: str) -> None:
+    out.write_text(f"1\n00:00:00,500 --> 00:00:03,000\n{text}\n", encoding="utf-8")
+
+
+def build_hdr10_multitrack(out: Path) -> None:
+    """HDR10 HEVC targeting the full track-structure set (extra-video, duplicate, redundant-default,
+    flags-to-set, unwanted-language, tags) and forcing an HDR-preserving remux.
+
+    Layout: two video tracks (extra video); two en audio both default (redundant default); two ja
+    audio both UNFLAGGED (duplicate - dedup keeps flagged tracks, so these must be flagless and in a
+    keep language); one de audio + one de subtitle (unwanted language); one en subtitle titled
+    "Forced" without the forced flag (flags to be set); statistics tags + title (tags).
+    """
+    with tempfile.TemporaryDirectory() as td:
+        work = Path(td)
+        base, sdr, aud = work / "base.mkv", work / "sdr.mkv", work / "aud.m4a"
+        sub_en, sub_de = work / "en.srt", work / "de.srt"
+        gen_hdr10_base(base)
+        gen_sdr_video(sdr)
+        gen_audio(aud)
+        write_srt(sub_en, "Hello World")
+        write_srt(sub_de, "Hallo Welt")
+        run(
+            [MKVMERGE, "-o", str(out), "--title", "Synthetic HDR10 Multitrack",
+             "--default-track-flag", "0:no", "--language", "0:en", "--track-name", "0:HDR10 Main", str(base),
+             "--default-track-flag", "0:no", "--language", "0:en", "--track-name", "0:Thumbnail", str(sdr),
+             "--default-track-flag", "0:yes", "--language", "0:en", "--track-name", "0:English", str(aud),
+             "--default-track-flag", "0:yes", "--language", "0:en", "--track-name", "0:English 2", str(aud),
+             "--default-track-flag", "0:no", "--language", "0:ja", "--track-name", "0:Japanese", str(aud),
+             "--default-track-flag", "0:no", "--language", "0:ja", "--track-name", "0:Japanese 2", str(aud),
+             "--default-track-flag", "0:no", "--language", "0:de", "--track-name", "0:German", str(aud),
+             "--default-track-flag", "0:no", "--language", "0:en", "--track-name", "0:English Forced", str(sub_en),
+             "--default-track-flag", "0:no", "--language", "0:de", "--track-name", "0:German Subs", str(sub_de)]
+        )  # fmt: skip
+
+
+def build_hdr10_cc(out: Path) -> None:
+    """HDR10 HEVC with embedded CEA-608 closed captions, targeting the CC-on-HDR branch.
+
+    HDR10 (ST 2086) is enough to reach the branch. For the true HDR10+ (ST 2094) case - the dynamic
+    metadata genuinely at risk when the CC SEI is removed - also inject an ST 2094-40 SEI.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        work = Path(td)
+        base, annexb, ccb = work / "base.mkv", work / "base.hevc", work / "cc.hevc"
+        gen_hdr10_base(base)
+        run(
+            [
+                FFMPEG,
+                "-y",
+                "-i",
+                str(base),
+                "-c:v",
+                "copy",
+                "-bsf:v",
+                "hevc_mp4toannexb",
+                str(annexb),
+            ]
+        )
+        ccb.write_bytes(inject(annexb.read_bytes()))
+        run([MKVMERGE, "-o", str(out), "--default-duration", "0:24fps", str(ccb)])
+
+
+TARGETS: dict[str, Callable[[Path], None]] = {
+    "hdr10-base": gen_hdr10_base,
+    "hdr10-multitrack": build_hdr10_multitrack,
+    "hdr10-cc": build_hdr10_cc,
+}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("target", choices=sorted(TARGETS), help="which synthetic fixture to build")
+    ap.add_argument("-o", "--out", required=True, type=Path, help="output file")
+    args = ap.parse_args()
+    TARGETS[args.target](args.out)
+    print(f"built {args.target} -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/RegressionTests/synthetic/synthesize.py
+++ b/RegressionTests/synthetic/synthesize.py
@@ -42,13 +42,19 @@ HDR10_X265 = (
 
 
 def run(cmd: list[str]) -> None:
-    subprocess.run(
+    # Capture combined output and surface its tail on failure, so a regeneration error on another
+    # machine is diagnosable rather than a bare non-zero exit.
+    proc = subprocess.run(
         cmd,
-        check=True,
         stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        errors="replace",
     )
+    if proc.returncode != 0:
+        tail = "\n".join((proc.stdout or "").splitlines()[-20:])
+        raise RuntimeError(f"command failed (exit {proc.returncode}): {' '.join(cmd)}\n{tail}")
 
 
 def gen_hdr10_base(out: Path, seconds: int = 6, width: int = 3840, height: int = 2160) -> None:


### PR DESCRIPTION
Add `RegressionTests/synthetic/` as the start of a synthetic-targeting library: build small, fully
synthetic media (ffmpeg `lavfi` sources — no copyrighted content) that reproduce specific PlexCleaner
detections, so a regression fixture can be regenerated anywhere without shipping media.

- **`synthesize.py`** — generation primitives (HDR10 base, SDR video, audio, subtitles) plus builders
  that target a detection set (`hdr10-multitrack` for the track-structure set; `hdr10-cc` for HDR10 +
  closed captions) and a small CLI. Validated by processing through the image and matching detections.
- **`inject_cc_sei.py`** — insert CEA-608 closed-caption SEI into an HEVC stream (no common tool does
  this: ffmpeg `-a53cc` is libx264 only, libx265 drops captions), preserving any HDR SEI, so the file
  reaches the CC-on-HDR code path. Importable or a standalone CLI.

The README gains a **Synthetic file generation** section: the targeting methodology (build → validate
by prove-equivalence), the verified per-detection rules (e.g. the dedup keeps flagged tracks, so a
duplicate pair must be unflagged and in a keep language; `SetFlags` fires from a title-implied flag),
and how to extend it.

Requires ffmpeg (libx265) + mkvmerge to run; stdlib-only otherwise (ruff + mypy clean). Everything is
synthetic — no media or media filenames are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)