### PR TITLE
Add an HDR10+ (ST 2094) SEI Injector and hdr10plus-cc Target

### DIFF
--- a/RegressionTests/README.md
+++ b/RegressionTests/README.md
@@ -159,12 +159,18 @@ a targeted mux -- so a fixture can be regenerated anywhere with no media to ship
 - [`synthetic/inject_cc_sei.py`](synthetic/inject_cc_sei.py) -- insert CEA-608 closed-caption SEI
   into an HEVC stream (no common tool does this: ffmpeg `-a53cc` is libx264 only, libx265 drops
   captions), preserving any HDR SEI. Importable, or a standalone CLI.
+- [`synthetic/inject_hdr10plus_sei.py`](synthetic/inject_hdr10plus_sei.py) -- insert a minimal
+  SMPTE ST 2094-40 (HDR10+) dynamic-metadata SEI (the shipped x265 builds lack `dhdr10`), so a base
+  reports "SMPTE ST 2094 App 4". Importable, or a standalone CLI.
+- [`synthetic/hevc_nal.py`](synthetic/hevc_nal.py) -- shared HEVC helpers (bit packing, wrapping a
+  T.35 payload into a prefix-SEI NAL, inserting a SEI before every VCL NAL) used by both injectors.
 
 Requires `ffmpeg` (with libx265) and `mkvmerge` on `PATH`. Examples:
 
 ```shell
 python3 synthetic/synthesize.py hdr10-multitrack -o multitrack.mkv   # targets the track-structure set
-python3 synthetic/synthesize.py hdr10-cc -o hdr-cc.mkv               # HDR10 HEVC with closed captions
+python3 synthetic/synthesize.py hdr10-cc -o hdr-cc.mkv               # HDR10 (ST 2086) HEVC + closed captions
+python3 synthetic/synthesize.py hdr10plus-cc -o hdr10plus-cc.mkv     # true HDR10+ (ST 2094) HEVC + closed captions
 ```
 
 ### Targeting methodology
@@ -184,15 +190,17 @@ matches the target. The builders encode what actually triggers each detection (v
 - **Tags** -- mkvmerge statistics tags plus a container title.
 - **HDR survives remux** -- the HDR SEI is copied through an mkvmerge remux; pairing it with a
   removable track (above) forces the remux, so the fixture guards HDR passthrough during cleanup.
-- **Closed captions on HDR** -- an injected A53 CC SEI on an HDR (ST 2086 / 2094) HEVC stream
-  reaches the CC-on-HDR branch (which refuses removal to avoid stripping HDR metadata).
+- **Closed captions on HDR** -- an injected A53 CC SEI on an HDR HEVC stream reaches the CC-on-HDR
+  branch (which refuses removal to avoid stripping HDR metadata). `hdr10-cc` builds the static
+  ST 2086 case; `hdr10plus-cc` also injects an ST 2094-40 SEI so the branch fires over the *dynamic*
+  HDR10+ metadata that is genuinely at risk when the CC SEI is removed.
 
 ### Extending the library
 
 Add a builder function that constructs the target with the primitives, register it in `TARGETS`,
 and validate it through the image. Keep everything synthetic (or publicly sourced) -- never commit
-copyrighted media or media filenames. Candidate next steps: an HDR10+ (ST 2094) SEI injector to make
-the closed-caption fixture true HDR10+, and interlaced / cover-art / container-specific targets.
+copyrighted media or media filenames. Candidate next steps: interlaced, cover-art, and
+container-specific (AVI / WMV / MPEG-2) targets, and per-frame-varying HDR10+ metadata.
 
 ## Naming conventions
 

--- a/RegressionTests/README.md
+++ b/RegressionTests/README.md
@@ -160,8 +160,8 @@ a targeted mux -- so a fixture can be regenerated anywhere with no media to ship
   into an HEVC stream (no common tool does this: ffmpeg `-a53cc` is libx264 only, libx265 drops
   captions), preserving any HDR SEI. Importable, or a standalone CLI.
 - [`synthetic/inject_hdr10plus_sei.py`](synthetic/inject_hdr10plus_sei.py) -- insert a minimal
-  SMPTE ST 2094-40 (HDR10+) dynamic-metadata SEI (the shipped x265 builds lack `dhdr10`), so a base
-  reports "SMPTE ST 2094 App 4". Importable, or a standalone CLI.
+  SMPTE ST 2094-40 (HDR10+) dynamic-metadata SEI (the shipped x265 builds lack `dhdr10`), so
+  MediaInfo reports the stream as "SMPTE ST 2094 App 4". Importable, or a standalone CLI.
 - [`synthetic/hevc_nal.py`](synthetic/hevc_nal.py) -- shared HEVC helpers (bit packing, wrapping a
   T.35 payload into a prefix-SEI NAL, inserting a SEI before every VCL NAL) used by both injectors.
 

--- a/RegressionTests/synthetic/hevc_nal.py
+++ b/RegressionTests/synthetic/hevc_nal.py
@@ -62,8 +62,10 @@ def wrap_sei_t35(payload: bytes) -> bytes:
 def insert_before_vcl(data: bytes, sei: bytes) -> bytes:
     """Return the Annex-B HEVC stream with ``sei`` inserted before every VCL NAL.
 
-    ``re.finditer`` on ``00 00 01`` matches both 3- and 4-byte start codes (a 4-byte code's leading
-    ``00`` is trimmed from the previous NAL). Empty NALs from consecutive start codes are skipped.
+    ``re.finditer`` on ``00 00 01`` locates each start code; any number of leading ``zero_byte``
+    padding before it (a 4-byte ``00 00 00 01`` or more) is stripped from the previous NAL, which is
+    safe because a well-formed NAL never ends in ``0x00``. Empty NALs from consecutive start codes
+    are skipped.
     """
     starts = [m.start() for m in re.finditer(b"\x00\x00\x01", data)]
     if not starts:
@@ -72,8 +74,9 @@ def insert_before_vcl(data: bytes, sei: bytes) -> bytes:
     for i, start in enumerate(starts):
         payload_start = start + 3
         if i + 1 < len(starts):
-            nxt = starts[i + 1]
-            payload_end = nxt - 1 if data[nxt - 1] == 0 else nxt
+            payload_end = starts[i + 1]
+            while payload_end > payload_start and data[payload_end - 1] == 0:
+                payload_end -= 1
         else:
             payload_end = len(data)
         nal = data[payload_start:payload_end]

--- a/RegressionTests/synthetic/hevc_nal.py
+++ b/RegressionTests/synthetic/hevc_nal.py
@@ -1,0 +1,81 @@
+"""Shared HEVC Annex-B NAL helpers for the SEI injectors.
+
+Both the closed-caption and HDR10+ injectors build a ``user_data_registered_itu_t_t35`` SEI
+(payload type 4) and insert it before every VCL NAL. This module holds the parts they share: bit
+packing, wrapping a T.35 payload into a prefix-SEI NAL, and walking the Annex-B start codes.
+"""
+
+import re
+
+
+class BitWriter:
+    """Minimal MSB-first bit accumulator that packs to whole bytes (zero-padded)."""
+
+    def __init__(self) -> None:
+        self._bits: list[int] = []
+
+    def write(self, value: int, count: int) -> None:
+        for i in range(count - 1, -1, -1):
+            self._bits.append((value >> i) & 1)
+
+    def to_bytes(self) -> bytes:
+        while len(self._bits) % 8:
+            self._bits.append(0)
+        out = bytearray()
+        for i in range(0, len(self._bits), 8):
+            byte = 0
+            for bit in self._bits[i : i + 8]:
+                byte = (byte << 1) | bit
+            out.append(byte)
+        return bytes(out)
+
+
+def wrap_sei_t35(payload: bytes) -> bytes:
+    """Wrap a T.35 payload into a prefix-SEI (type 39) NAL, with a start code.
+
+    Builds ``payloadType=4`` + the ff-coded payload size + payload + rbsp trailing, applies
+    emulation prevention (``0x000003``), and prepends the 4-byte start code and the 2-byte HEVC
+    prefix-SEI NAL header.
+    """
+    size = bytearray()
+    remaining = len(payload)
+    while remaining >= 255:
+        size.append(0xFF)
+        remaining -= 255
+    size.append(remaining)
+    rbsp = bytes([0x04]) + bytes(size) + payload + bytes([0x80])
+    ep = bytearray()
+    zeros = 0
+    for byte in rbsp:
+        if zeros >= 2 and byte <= 3:
+            ep.append(0x03)
+            zeros = 0
+        ep.append(byte)
+        zeros = zeros + 1 if byte == 0 else 0
+    return b"\x00\x00\x00\x01" + bytes([0x4E, 0x01]) + bytes(ep)
+
+
+def insert_before_vcl(data: bytes, sei: bytes) -> bytes:
+    """Return the Annex-B HEVC stream with ``sei`` inserted before every VCL NAL.
+
+    ``re.finditer`` on ``00 00 01`` matches both 3- and 4-byte start codes (a 4-byte code's leading
+    ``00`` is trimmed from the previous NAL). Empty NALs from consecutive start codes are skipped.
+    """
+    starts = [m.start() for m in re.finditer(b"\x00\x00\x01", data)]
+    if not starts:
+        raise ValueError("input is not an Annex-B HEVC stream (no start codes found)")
+    out = bytearray()
+    for i, start in enumerate(starts):
+        payload_start = start + 3
+        if i + 1 < len(starts):
+            nxt = starts[i + 1]
+            payload_end = nxt - 1 if data[nxt - 1] == 0 else nxt
+        else:
+            payload_end = len(data)
+        nal = data[payload_start:payload_end]
+        if not nal:
+            continue
+        if (nal[0] >> 1) & 0x3F < 32:  # VCL NAL -> prepend the SEI
+            out += sei
+        out += b"\x00\x00\x00\x01" + nal
+    return bytes(out)

--- a/RegressionTests/synthetic/hevc_nal.py
+++ b/RegressionTests/synthetic/hevc_nal.py
@@ -15,6 +15,10 @@ class BitWriter:
         self._bits: list[int] = []
 
     def write(self, value: int, count: int) -> None:
+        if count < 1:
+            raise ValueError("count must be >= 1")
+        if not 0 <= value < (1 << count):
+            raise ValueError(f"value {value} does not fit in {count} bits")
         for i in range(count - 1, -1, -1):
             self._bits.append((value >> i) & 1)
 

--- a/RegressionTests/synthetic/inject_cc_sei.py
+++ b/RegressionTests/synthetic/inject_cc_sei.py
@@ -4,8 +4,8 @@ No common tool embeds closed captions into HEVC - ffmpeg ``-a53cc`` is libx264 o
 drops caption side data. This inserts a prefix-SEI NAL (type 39) carrying an A53
 ``user_data_registered_itu_t_t35`` cc_data payload before every VCL NAL, leaving any existing HDR
 SEI (mastering-display / MaxCLL, and any HDR10+ ST 2094) in place. The result is an HDR + CC HEVC
-stream where ffprobe/MediaInfo report ``closed_captions=1`` and PlexCleaner reaches its
-CC-on-HDR branch (which errors rather than removing CC, to avoid stripping HDR metadata).
+stream where ffprobe/MediaInfo report ``closed_captions=1`` and PlexCleaner reaches its CC-on-HDR
+branch (which errors rather than removing CC, to avoid stripping HDR metadata).
 
 Standalone use::
 
@@ -13,20 +13,20 @@ Standalone use::
     python3 inject_cc_sei.py base.hevc cc.hevc
     mkvmerge -o out.mkv --default-duration 0:24fps cc.hevc
 
-Or import ``inject(hevc_bytes) -> hevc_bytes`` from another script.
+Or import ``build_cc_sei()`` / ``inject(hevc_bytes) -> hevc_bytes`` from another script.
 """
 
-import re
 import sys
 from pathlib import Path
+
+from hevc_nal import insert_before_vcl, wrap_sei_t35
 
 
 def build_cc_sei(cc_count: int = 1) -> bytes:
     """Build one prefix-SEI NAL (type 39) carrying an A53 CEA-608 cc_data payload.
 
     The captions are minimal but validly structured: field-1, cc_valid, null (odd-parity) bytes -
-    enough for the decoder to attach A53 side data and set the closed-captions property. Emulation
-    prevention (``0x000003``) is applied to the RBSP.
+    enough for the decoder to attach A53 side data and set the closed-captions property.
     """
     if not 1 <= cc_count <= 31:
         raise ValueError("cc_count must be 1..31 (the cc_count field is 5 bits)")
@@ -36,42 +36,12 @@ def build_cc_sei(cc_count: int = 1) -> bytes:
         + triples
         + bytes([0xFF])
     )
-    sei = bytes([0x04, len(payload)]) + payload  # payloadType=4 (t35), payloadSize
-    rbsp = sei + bytes([0x80])  # rbsp_trailing_bits
-    ep = bytearray()  # emulation prevention: 0x03 after any 00 00 {00..03}
-    zeros = 0
-    for byte in rbsp:
-        if zeros >= 2 and byte <= 3:
-            ep.append(0x03)
-            zeros = 0
-        ep.append(byte)
-        zeros = zeros + 1 if byte == 0 else 0
-    return b"\x00\x00\x00\x01" + bytes([0x4E, 0x01]) + bytes(ep)  # prefix-SEI NAL (type 39)
+    return wrap_sei_t35(payload)
 
 
 def inject(data: bytes) -> bytes:
     """Return the Annex-B HEVC stream with a CC SEI inserted before every VCL NAL."""
-    cc = build_cc_sei()
-    # re.finditer on 00 00 01 matches both 3- and 4-byte start codes (the 4-byte code's trailing
-    # 00 00 01 is found; its leading 00 is trimmed from the previous NAL below).
-    starts = [m.start() for m in re.finditer(b"\x00\x00\x01", data)]
-    if not starts:
-        raise ValueError("input is not an Annex-B HEVC stream (no start codes found)")
-    out = bytearray()
-    for i, start in enumerate(starts):
-        payload_start = start + 3
-        if i + 1 < len(starts):
-            nxt = starts[i + 1]
-            payload_end = nxt - 1 if data[nxt - 1] == 0 else nxt
-        else:
-            payload_end = len(data)
-        nal = data[payload_start:payload_end]
-        if not nal:  # consecutive start codes -> empty NAL, skip
-            continue
-        if (nal[0] >> 1) & 0x3F < 32:  # VCL NAL -> prepend the CC SEI
-            out += cc
-        out += b"\x00\x00\x00\x01" + nal
-    return bytes(out)
+    return insert_before_vcl(data, build_cc_sei())
 
 
 def main() -> None:

--- a/RegressionTests/synthetic/inject_hdr10plus_sei.py
+++ b/RegressionTests/synthetic/inject_hdr10plus_sei.py
@@ -1,0 +1,64 @@
+"""Inject a minimal SMPTE ST 2094-40 (HDR10+) dynamic-metadata SEI into an HEVC Annex-B stream.
+
+HDR10+ metadata is a ``user_data_registered_itu_t_t35`` SEI (Samsung terminal provider ``0x003C``,
+application identifier 4) carrying bit-packed ST 2094-40 tone-mapping metadata. No common tool emits
+it (the shipped x265 builds lack ``dhdr10`` support), so this constructs a minimal but structurally
+valid payload - one window, the nine standard distribution percentiles, no tone-mapping curve - and
+inserts it as a prefix-SEI NAL before every VCL NAL, preserving any existing SEI. MediaInfo then
+reports "SMPTE ST 2094 App 4". Pair it with the closed-caption injector to reach PlexCleaner's
+CC-on-HDR branch over the dynamic metadata that is genuinely at risk when the CC SEI is removed.
+
+Standalone use::
+
+    ffmpeg -i in.mkv -c:v copy -bsf:v hevc_mp4toannexb base.hevc
+    python3 inject_hdr10plus_sei.py base.hevc hdr10plus.hevc
+    mkvmerge -o out.mkv --default-duration 0:24fps hdr10plus.hevc
+
+Or import ``build_hdr10plus_sei()`` / ``inject(hevc_bytes) -> hevc_bytes`` from another script.
+"""
+
+import sys
+from pathlib import Path
+
+from hevc_nal import BitWriter, insert_before_vcl, wrap_sei_t35
+
+# ST 2094-40 distribution percentages (the standard nine)
+_PERCENTAGES = (1, 5, 10, 25, 50, 75, 90, 95, 99)
+
+
+def build_hdr10plus_sei() -> bytes:
+    """Build one prefix-SEI NAL (type 39) carrying a minimal ST 2094-40 HDR10+ payload."""
+    # T.35 header: country 0xB5, terminal provider 0x003C, oriented 0x0001, app id 4, app version 1
+    header = bytes([0xB5, 0x00, 0x3C, 0x00, 0x01, 0x04, 0x01])
+    bw = BitWriter()
+    bw.write(1, 2)  # num_windows = 1
+    bw.write(400, 27)  # targeted_system_display_maximum_luminance
+    bw.write(0, 1)  # targeted_system_display_actual_peak_luminance_flag
+    for _ in range(3):
+        bw.write(1000, 17)  # maxscl[0..2]
+    bw.write(500, 17)  # average_maxrgb
+    bw.write(len(_PERCENTAGES), 4)  # num_distribution_maxrgb_percentiles
+    for percentage in _PERCENTAGES:
+        bw.write(percentage, 7)  # distribution_maxrgb_percentage
+        bw.write(0, 17)  # distribution_maxrgb_percentile
+    bw.write(0, 10)  # fraction_bright_pixels
+    bw.write(0, 1)  # mastering_display_actual_peak_luminance_flag
+    bw.write(0, 1)  # tone_mapping_flag (no bezier curve)
+    bw.write(0, 1)  # color_saturation_mapping_flag
+    return wrap_sei_t35(header + bw.to_bytes())
+
+
+def inject(data: bytes) -> bytes:
+    """Return the Annex-B HEVC stream with an HDR10+ SEI inserted before every VCL NAL."""
+    return insert_before_vcl(data, build_hdr10plus_sei())
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        sys.exit("usage: inject_hdr10plus_sei.py <in.hevc> <out.hevc>")
+    Path(sys.argv[2]).write_bytes(inject(Path(sys.argv[1]).read_bytes()))
+    print(f"injected HDR10+ SEI before each VCL NAL -> {sys.argv[2]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/RegressionTests/synthetic/synthesize.py
+++ b/RegressionTests/synthetic/synthesize.py
@@ -28,7 +28,9 @@ import tempfile
 from collections.abc import Callable
 from pathlib import Path
 
-from inject_cc_sei import inject
+from hevc_nal import insert_before_vcl
+from inject_cc_sei import build_cc_sei
+from inject_hdr10plus_sei import build_hdr10plus_sei
 
 FFMPEG = "ffmpeg"
 MKVMERGE = "mkvmerge"
@@ -120,37 +122,37 @@ def build_hdr10_multitrack(out: Path) -> None:
         )  # fmt: skip
 
 
-def build_hdr10_cc(out: Path) -> None:
-    """HDR10 HEVC with embedded CEA-608 closed captions, targeting the CC-on-HDR branch.
-
-    HDR10 (ST 2086) is enough to reach the branch. For the true HDR10+ (ST 2094) case - the dynamic
-    metadata genuinely at risk when the CC SEI is removed - also inject an ST 2094-40 SEI.
-    """
+def _build_hdr_cc(out: Path, sei: bytes) -> None:
+    """Generate the HDR10 base, inject ``sei`` (HDR + CC) before every VCL NAL, and remux to MKV."""
     with tempfile.TemporaryDirectory() as td:
         work = Path(td)
         base, annexb, ccb = work / "base.mkv", work / "base.hevc", work / "cc.hevc"
         gen_hdr10_base(base)
-        run(
-            [
-                FFMPEG,
-                "-y",
-                "-i",
-                str(base),
-                "-c:v",
-                "copy",
-                "-bsf:v",
-                "hevc_mp4toannexb",
-                str(annexb),
-            ]
-        )
-        ccb.write_bytes(inject(annexb.read_bytes()))
+        run([FFMPEG, "-y", "-i", str(base), "-c:v", "copy", "-bsf:v", "hevc_mp4toannexb", str(annexb)])  # fmt: skip
+        ccb.write_bytes(insert_before_vcl(annexb.read_bytes(), sei))
         run([MKVMERGE, "-o", str(out), "--default-duration", "0:24fps", str(ccb)])
+
+
+def build_hdr10_cc(out: Path) -> None:
+    """HDR10 (ST 2086) HEVC with CEA-608 closed captions, reaching the CC-on-HDR branch."""
+    _build_hdr_cc(out, build_cc_sei())
+
+
+def build_hdr10plus_cc(out: Path) -> None:
+    """True HDR10+ (ST 2094) HEVC with CEA-608 closed captions.
+
+    Injects both an ST 2094-40 HDR10+ SEI and the CC SEI, so the CC-on-HDR branch fires over the
+    dynamic metadata that is genuinely at risk when the CC SEI is removed (MediaInfo reports
+    "SMPTE ST 2094 App 4"), not just the static ST 2086 case.
+    """
+    _build_hdr_cc(out, build_hdr10plus_sei() + build_cc_sei())
 
 
 TARGETS: dict[str, Callable[[Path], None]] = {
     "hdr10-base": gen_hdr10_base,
     "hdr10-multitrack": build_hdr10_multitrack,
     "hdr10-cc": build_hdr10_cc,
+    "hdr10plus-cc": build_hdr10plus_cc,
 }
 
 

--- a/RegressionTests/synthetic/synthesize.py
+++ b/RegressionTests/synthetic/synthesize.py
@@ -123,7 +123,11 @@ def build_hdr10_multitrack(out: Path) -> None:
 
 
 def _build_hdr_cc(out: Path, sei: bytes) -> None:
-    """Generate the HDR10 base, inject ``sei`` (HDR + CC) before every VCL NAL, and remux to MKV."""
+    """Generate the HDR10 base, inject the given SEI NAL(s) before every VCL NAL, and remux to MKV.
+
+    ``sei`` is the caption SEI, optionally preceded by an HDR10+ (ST 2094) SEI; the HDR10 (ST 2086)
+    base metadata always comes from the x265 encode of the base.
+    """
     with tempfile.TemporaryDirectory() as td:
         work = Path(td)
         base, annexb, ccb = work / "base.mkv", work / "base.hevc", work / "cc.hevc"


### PR DESCRIPTION
Extend `RegressionTests/synthetic/` so the closed-caption-on-HDR fixture can be **true HDR10+**, not
just static HDR10.

- **`hevc_nal.py`** — factor the shared HEVC helpers (bit packing, wrapping a T.35 payload into a
  prefix-SEI NAL, inserting a SEI before every VCL NAL) used by both injectors, removing the
  NAL/SEI duplication.
- **`inject_hdr10plus_sei.py`** — construct a minimal but valid SMPTE ST 2094-40 (HDR10+)
  dynamic-metadata SEI (Samsung provider `0x003C`, app id 4; one window, nine standard percentiles)
  and insert it. MediaInfo then reports `SMPTE ST 2094 App 4`. Importable or a CLI.
- **`synthesize.py`** — refactor `inject_cc_sei` onto the shared helpers, and add the `hdr10plus-cc`
  target (ST 2094 SEI + CC SEI) so the CC-on-HDR branch fires over the dynamic metadata genuinely at
  risk when the CC SEI is removed, not just the static ST 2086 case.

Validated end-to-end: `hdr10plus-cc` produces MediaInfo `SMPTE ST 2094 App 4` + ffprobe
`closed_captions=1`, and processing it fires `Removing Closed Captions may remove HDR10+ information
: "SMPTE ST 2094 App 4"`. `hdr10-cc` (ST 2086) still works. All synthetic — no media committed; ruff
+ mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)