### PR TITLE
Add artificial-container and relaxed-accept reduction rungs

### DIFF
--- a/RegressionTests/README.md
+++ b/RegressionTests/README.md
@@ -71,7 +71,7 @@ Any miss keeps the original whole, so an issue is never dropped.
 
 Cutting a clip can silently repair the very defect the sample exists to capture, and the two cutters have mirror-image side effects: an `mkvmerge` cut preserves timestamp defects but strips language-IETF metadata, while an `ffmpeg` cut preserves metadata but normalizes some timestamp defects. So the tool tries a ladder of cutters plus in-place metadata surgery and lets the prove-equivalence gate pick the one that keeps this file's issues:
 
-- head clips and region clips via `mkvmerge` and `ffmpeg`.
+- head clips and region clips via `mkvmerge` and `ffmpeg`. The order is defect-type driven: a decode-signature file (its defect lives in the video packets) tries the `ffmpeg` stream-copy first, because `mkvmerge` can pass the coarse gate while losing the physical error shape; other files try `mkvmerge` first, to preserve timestamp defects `ffmpeg` would normalize.
 - surgical rungs that edit the header in place with no remux: a `noietf` rung re-injects the missing-IETF-metadata defect an `mkvmerge` cut would repair, and a `fixietf` rung sets IETF on an `ffmpeg` cut so a timestamp defect drives the verify-and-repair chain.
 - an `artificial-container` last-resort rung that re-muxes the head with the MP4 muxer under the `.mkv` name, reproducing a source that IS a renamed MP4. It sits after every real MKV cutter, so a genuine MKV never reaches it (and would be rejected by the gate if it did).
 

--- a/RegressionTests/README.md
+++ b/RegressionTests/README.md
@@ -77,7 +77,7 @@ Cutting a clip can silently repair the very defect the sample exists to capture,
 
 Samples at or near the window length ship verbatim, because any cut remuxes and would repair container or metadata defects.
 
-Some samples reproduce their defect but diverge from the source by a known, benign amount -- a downstream artifact of a repair that depends on full-file content, not the defect itself (for example a remux the 60s clip cannot trigger). Rather than keep the whole source, an `accept` rule in the external rules file declares the exact, bounded State/detection delta tolerated for a named rung; a clip within that bound passes as `relaxed` and the catalog records the delta so the divergence stays explicit.
+Some samples reproduce their defect but diverge from the source by a known, benign amount -- a downstream artifact of a repair that depends on full-file content, not the defect itself (for example a remux the 60s clip cannot trigger). Rather than keep the whole source, an `accept` rule in the external rules file declares the exact, bounded delta tolerated for a named rung -- in State, detections, or verify-error signatures; a clip within that bound passes as `relaxed` and the catalog records the delta so the divergence stays explicit.
 
 ### Region rules (generate on demand)
 

--- a/RegressionTests/README.md
+++ b/RegressionTests/README.md
@@ -73,8 +73,11 @@ Cutting a clip can silently repair the very defect the sample exists to capture,
 
 - head clips and region clips via `mkvmerge` and `ffmpeg`.
 - surgical rungs that edit the header in place with no remux: a `noietf` rung re-injects the missing-IETF-metadata defect an `mkvmerge` cut would repair, and a `fixietf` rung sets IETF on an `ffmpeg` cut so a timestamp defect drives the verify-and-repair chain.
+- an `artificial-container` last-resort rung that re-muxes the head with the MP4 muxer under the `.mkv` name, reproducing a source that IS a renamed MP4. It sits after every real MKV cutter, so a genuine MKV never reaches it (and would be rejected by the gate if it did).
 
 Samples at or near the window length ship verbatim, because any cut remuxes and would repair container or metadata defects.
+
+Some samples reproduce their defect but diverge from the source by a known, benign amount -- a downstream artifact of a repair that depends on full-file content, not the defect itself (for example a remux the 60s clip cannot trigger). Rather than keep the whole source, an `accept` rule in the external rules file declares the exact, bounded State/detection delta tolerated for a named rung; a clip within that bound passes as `relaxed` and the catalog records the delta so the divergence stays explicit.
 
 ### Region rules (generate on demand)
 
@@ -90,7 +93,7 @@ python3 locate_issue.py --catalog /path/to/full/catalog.json --full --write-rule
 python3 reduce_corpus.py --catalog /path/to/full/catalog.json --mode generate --out /path/to/reduced
 ```
 
-The rules schema is a `regions` map keyed by source basename; see [`reduction-rules.example.json`](reduction-rules.example.json). If the rules file is absent, every file is head-clipped and the tool says so.
+The rules schema has a `regions` map (issue-localized cut windows) and an `accept` map (relaxed-acceptance overrides), both keyed by source basename; see [`reduction-rules.example.json`](reduction-rules.example.json). If the rules file is absent, every file is head-clipped, no relaxed acceptance applies, and the tool says so.
 
 ## Physical-shape coverage audit
 

--- a/RegressionTests/corpus_common.py
+++ b/RegressionTests/corpus_common.py
@@ -312,6 +312,10 @@ def error_shape(e):
     s = re.sub(r"\[dec:(\w+) @ 0xADDR\]\s*", r"[\1] ", s)  # [dec:h264 @ ..]
     s = re.sub(r"\[(\w+) @ 0xADDR\]", r"[\1]", s)  # [h264 @ ..]
     s = re.sub(r"\[SWR @ 0xADDR\]", "[SWR]", s)
+    # collapse the collection subdir in an embedded source path: the ground run processes files
+    # under full/ while a clip is processed at the media root, so a path-bearing message (e.g. the
+    # unsupported-container error) would otherwise never match between ground and clip
+    s = re.sub(r"<MEDIA>/\w+/", "<MEDIA>/", s)
     s = re.sub(r"stream \d+", "stream N", s)
     s = re.sub(r"-?\b\d+(\.\d+)?\b", "N", s)  # coordinates/ids/sizes
     return re.sub(r"\s+", " ", s).strip()

--- a/RegressionTests/corpus_common.py
+++ b/RegressionTests/corpus_common.py
@@ -312,10 +312,11 @@ def error_shape(e):
     s = re.sub(r"\[dec:(\w+) @ 0xADDR\]\s*", r"[\1] ", s)  # [dec:h264 @ ..]
     s = re.sub(r"\[(\w+) @ 0xADDR\]", r"[\1]", s)  # [h264 @ ..]
     s = re.sub(r"\[SWR @ 0xADDR\]", "[SWR]", s)
-    # collapse the collection subdir in an embedded source path: the ground run processes files
-    # under full/ while a clip is processed at the media root, so a path-bearing message (e.g. the
-    # unsupported-container error) would otherwise never match between ground and clip
-    s = re.sub(r"<MEDIA>/\w+/", "<MEDIA>/", s)
+    # collapse the known collection subdir in an embedded source path: the ground run processes
+    # files under full/ while a clip is processed at the media root, so a path-bearing message
+    # (e.g. the unsupported-container error) would otherwise never match between ground and clip.
+    # Restricted to the corpus dirs so a real top-level path component is never stripped.
+    s = re.sub(r"<MEDIA>/(?:full|reduced)/", "<MEDIA>/", s)
     s = re.sub(r"stream \d+", "stream N", s)
     s = re.sub(r"-?\b\d+(\.\d+)?\b", "N", s)  # coordinates/ids/sizes
     return re.sub(r"\s+", " ", s).strip()

--- a/RegressionTests/reduce_corpus.py
+++ b/RegressionTests/reduce_corpus.py
@@ -166,14 +166,16 @@ def make_artificial_container(src: Path, out: Path, seconds: int) -> bool:
     # glob would read as character classes and mis-match, deleting the wrong files or none
     for p in out.parent.glob(glob.escape(out.stem) + ".*"):
         p.unlink()
-    subprocess.run(
+    proc = subprocess.run(
         ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y", "-i", str(src),
          "-t", str(seconds), "-map", "0", "-c", "copy", "-f", "mp4", str(out)],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )  # fmt: skip
-    return out.exists() and out.stat().st_size > 0
+    # this remux has clean success/fail semantics (unlike the mkv cutters, which can exit non-zero
+    # yet leave a usable file), so require a clean exit as well as a non-empty output
+    return proc.returncode == 0 and out.exists() and out.stat().st_size > 0
 
 
 def process_clip(workdir: Path, settings_dir: Path) -> tuple[dict, dict[str, set[str]] | None]:

--- a/RegressionTests/reduce_corpus.py
+++ b/RegressionTests/reduce_corpus.py
@@ -17,11 +17,16 @@ Cutting strategy per file:
   windows for defects deep in the file
 - the cutter ladder tries mkvmerge and ffmpeg cuts plus in-place IETF surgery, because the cutters
   have mirror-image side effects and only the prove-equivalence gate can pick the safe one
+- ``artificial-container``: last-resort rung that re-muxes the head with the MP4 muxer under the
+  ``.mkv`` name, reproducing a source that IS a renamed MP4 (a genuine MKV fails the gate here)
+- relaxed acceptance (from the rules file): a named file may declare a bounded, benign State /
+  detection delta so a clip whose only shortfall is a documented downstream artifact still passes
 
 The source corpus is READ-ONLY. Clips, work dirs, and outputs live under scratch / --out.
 
-Media-specific region windows are NOT hard-coded here (that would embed private filenames); they
-live in an external rules file next to the corpus. See ``reduction-rules.example.json``.
+Media-specific data is NOT hard-coded here (that would embed private filenames); the region windows
+AND the relaxed-acceptance overrides live in an external rules file next to the corpus. See
+``reduction-rules.example.json``.
 
 Modes:
 
@@ -74,6 +79,21 @@ def load_regions(path: Path) -> dict[str, Region]:
     return {name: (int(r["start"]), int(r["end"])) for name, r in data.get("regions", {}).items()}
 
 
+def load_accept(path: Path) -> dict[str, dict]:
+    """Load relaxed-acceptance overrides from the external rules file.
+
+    A file with a genuine, benign divergence between its full-source and best-clip processing (a
+    downstream artifact of a repair that depends on full-file content, not the defect itself) would
+    otherwise fail the strict gate and be kept whole. An ``accept`` entry declares the exact,
+    bounded delta that is allowed for a NAMED rung, so the clip still ships while the divergence
+    stays explicit. Absent file / no ``accept`` section -> strict gate everywhere. See
+    ``reduction-rules.example.json`` for the schema.
+    """
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text()).get("accept", {})
+
+
 def make_clip(
     src: Path, out: Path, seconds: int, regions: dict[str, Region], cutter: str = "mkvmerge"
 ) -> bool:
@@ -124,6 +144,26 @@ def make_clip(
             numbered = out.with_name(out.stem + "-001" + out.suffix)
             if numbered.exists():
                 numbered.rename(out)
+    return out.exists() and out.stat().st_size > 0
+
+
+def make_artificial_container(src: Path, out: Path, seconds: int) -> bool:
+    """Head-clip [0, seconds] with the MP4 muxer but keep the ``.mkv`` name.
+
+    Reproduces a source that IS a renamed MP4: the byte stream is MP4 while the extension claims
+    Matroska, which PlexCleaner detects as a container mismatch and remuxes. For a genuine MKV this
+    produces an unrelated file that the prove-equivalence gate rejects, so it is only ever reached
+    as the last ladder rung, after the real MKV cutters have failed.
+    """
+    for p in out.parent.glob(out.stem + ".*"):
+        p.unlink()
+    subprocess.run(
+        ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y", "-i", str(src),
+         "-t", str(seconds), "-map", "0", "-c", "copy", "-f", "mp4", str(out)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )  # fmt: skip
     return out.exists() and out.stat().st_size > 0
 
 
@@ -227,8 +267,12 @@ def main() -> None:
     entries = {e["file"]: e for e in catalog["files"]}
     rules_path = Path(args.rules) if args.rules else catalog_path.parent / "reduction-rules.json"
     regions = load_regions(rules_path)
+    accept = load_accept(rules_path)
     print(f"Catalog      : {args.catalog}  ({len(entries)} files)")
-    print(f"Head window  : {args.seconds}s   regions: {len(regions)}   mode={args.mode}\n")
+    print(
+        f"Head window  : {args.seconds}s   regions: {len(regions)}   "
+        f"relaxed: {len(accept)}   mode={args.mode}\n"
+    )
 
     sources = args.sources or sorted(entries)
     settings_dir = Path(args.settings)
@@ -263,7 +307,12 @@ def main() -> None:
         if name in regions:
             ladder = ["region", "region-noietf", "region-ffmpeg", "region-ffmpeg-fixietf"]
         elif src.suffix.lower() == ".mkv":
-            ladder = ["mkvmerge", "mkvmerge-noietf", "ffmpeg-fixietf", "ffmpeg", "ffmpeg-tags"]
+            # artificial-container is a last-resort rung: it only reproduces a renamed-MP4 source,
+            # so it sits after every real MKV cutter and is reached only when they all fail.
+            ladder = [
+                "mkvmerge", "mkvmerge-noietf", "ffmpeg-fixietf", "ffmpeg", "ffmpeg-tags",
+                "artificial-container",
+            ]  # fmt: skip
         else:
             ladder = ["ffmpeg"]
 
@@ -287,6 +336,8 @@ def main() -> None:
                     regions,
                     cutter="ffmpeg" if base == "region-ffmpeg" else "mkvmerge",
                 )
+            elif base == "artificial-container":
+                made = make_artificial_container(src, pristine, args.seconds)
             else:
                 made = make_head_clip(src, pristine, args.seconds, cutter=base)
             if made and cutter.endswith("-noietf"):
@@ -326,7 +377,24 @@ def main() -> None:
             # source, which a single-site clip can never string-match
             miss_e = gt_subs - classify_signature(cl["errors"])
             state_ok = cl_state == gt_state
-            ok = state_ok and not miss_d and not miss_e
+            state_extra = cl_state - gt_state
+            state_short = gt_state - cl_state
+            strict_ok = state_ok and not miss_d and not miss_e
+            # Relaxed acceptance: when strict fails, an ``accept`` rule for THIS file and THIS rung
+            # may permit a bounded, documented delta (a benign downstream artifact) so the clip
+            # still passes; the clip is accepted only if every shortfall stays within the bound.
+            acc = accept.get(name)
+            relaxed = False
+            delta: dict = {}
+            if acc and cutter == acc.get("method") and not strict_ok:
+                over_short = state_short - set(acc.get("state_missing", []))
+                over_extra = state_extra - set(acc.get("state_extra", []))
+                over_d = miss_d - set(acc.get("detections_missing", []))
+                over_e = miss_e - set(acc.get("signatures_missing", []))
+                if not (over_short or over_extra or over_d or over_e):
+                    relaxed = True
+                    delta = {"missing": sorted(state_short), "extra": sorted(state_extra)}
+            ok = strict_ok or relaxed
             attempt = {
                 "cutter": cutter,
                 "pristine": pristine,
@@ -336,6 +404,8 @@ def main() -> None:
                 "miss_e": miss_e,
                 "state_ok": state_ok,
                 "verbatim": verbatim,
+                "relaxed": relaxed,
+                "state_delta": delta,
             }
             attempts.append(attempt)
             if ok or verbatim:
@@ -343,7 +413,11 @@ def main() -> None:
 
         csz = attempt.get("csz", ssz)
         ratio = f"{ssz / csz:.0f}x"
-        result = f"PASS ({attempt.get('cutter')})" if ok else "FAIL"
+        result = (
+            f"PASS ({attempt.get('cutter')}{', relaxed' if attempt.get('relaxed') else ''})"
+            if ok
+            else "FAIL"
+        )
         print(f"{short:54} {human(ssz):>7} {human(csz):>7} {ratio:>6}  {result}")
         if not ok and "error" in attempt:
             print(f"    {attempt['error']}")
@@ -383,6 +457,13 @@ def main() -> None:
                 "ground_state": sorted(gt_state),
                 "missing_detections": sorted(attempt.get("miss_d", set())),
                 "missing_signatures": sorted(attempt.get("miss_e", set())),
+                # relaxed passes carry the documented delta they were accepted with, so a divergence
+                # from ground stays explicit in the catalog rather than looking like a clean match
+                **(
+                    {"relaxed": True, "state_delta": attempt["state_delta"]}
+                    if ok and attempt.get("relaxed")
+                    else {}
+                ),
             }
         )
 

--- a/RegressionTests/reduce_corpus.py
+++ b/RegressionTests/reduce_corpus.py
@@ -19,8 +19,9 @@ Cutting strategy per file:
   have mirror-image side effects and only the prove-equivalence gate can pick the safe one
 - ``artificial-container``: last-resort rung that re-muxes the head with the MP4 muxer under the
   ``.mkv`` name, reproducing a source that IS a renamed MP4 (a genuine MKV fails the gate here)
-- relaxed acceptance (from the rules file): a named file may declare a bounded, benign State /
-  detection delta so a clip whose only shortfall is a documented downstream artifact still passes
+- relaxed acceptance (from the rules file): a named file may declare a bounded, benign delta in
+  State, detections, or verify-error signatures, so a clip whose only shortfall is a documented
+  downstream artifact still passes
 
 The source corpus is READ-ONLY. Clips, work dirs, and outputs live under scratch / --out.
 
@@ -36,6 +37,7 @@ Modes:
 """
 
 import argparse
+import glob
 import json
 import os
 import shutil
@@ -91,7 +93,10 @@ def load_accept(path: Path) -> dict[str, dict]:
     """
     if not path.exists():
         return {}
-    return json.loads(path.read_text()).get("accept", {})
+    raw = json.loads(path.read_text()).get("accept", {})
+    # keep only real rules: drop the "_comment" metadata key (and any non-dict value) so the
+    # relaxed count and the per-file lookup never treat a non-rule entry as an override
+    return {k: v for k, v in raw.items() if not k.startswith("_") and isinstance(v, dict)}
 
 
 def make_clip(
@@ -102,7 +107,9 @@ def make_clip(
     if not region:
         return make_head_clip(src, out, seconds)
     start, end = region
-    for p in out.parent.glob(out.stem + ".*"):
+    # escape the stem: corpus filenames contain glob metacharacters (e.g. brackets), which a raw
+    # glob would read as character classes and mis-match, deleting the wrong files or none
+    for p in out.parent.glob(glob.escape(out.stem) + ".*"):
         p.unlink()
     if cutter == "ffmpeg":
         # ffmpeg region cut gives cleaner timestamps at the cut boundary (a mkvmerge region cut can
@@ -155,7 +162,9 @@ def make_artificial_container(src: Path, out: Path, seconds: int) -> bool:
     produces an unrelated file that the prove-equivalence gate rejects, so it is only ever reached
     as the last ladder rung, after the real MKV cutters have failed.
     """
-    for p in out.parent.glob(out.stem + ".*"):
+    # escape the stem: corpus filenames contain glob metacharacters (e.g. brackets), which a raw
+    # glob would read as character classes and mis-match, deleting the wrong files or none
+    for p in out.parent.glob(glob.escape(out.stem) + ".*"):
         p.unlink()
     subprocess.run(
         ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y", "-i", str(src),
@@ -352,7 +361,11 @@ def main() -> None:
             verbatim = pristine.stat().st_size >= 0.5 * ssz
             if verbatim:
                 shutil.copy2(src, pristine)
-            elif pristine.suffix.lower() == ".mkv" and "ClearedTags" not in gt_state:
+            elif (
+                pristine.suffix.lower() == ".mkv"
+                and base != "artificial-container"  # an MP4-in-mkv clip is not real Matroska
+                and "ClearedTags" not in gt_state
+            ):
                 # both cutters add their own track tags (ffmpeg DURATION / mkvmerge statistics);
                 # when the source had none, strip them in place (no remux, defects untouched) so
                 # the clip does not pick up a spurious ClearedTags state

--- a/RegressionTests/reduce_corpus.py
+++ b/RegressionTests/reduce_corpus.py
@@ -318,10 +318,19 @@ def main() -> None:
         elif src.suffix.lower() == ".mkv":
             # artificial-container is a last-resort rung: it only reproduces a renamed-MP4 source,
             # so it sits after every real MKV cutter and is reached only when they all fail.
-            ladder = [
-                "mkvmerge", "mkvmerge-noietf", "ffmpeg-fixietf", "ffmpeg", "ffmpeg-tags",
-                "artificial-container",
-            ]  # fmt: skip
+            if gt_subs:
+                # decode-signature file: the defect lives in the video packets, which an ffmpeg
+                # stream-copy preserves faithfully. mkvmerge can pass the coarse gate while losing
+                # the physical error shape, so try the ffmpeg cutters first for these.
+                ladder = [
+                    "ffmpeg", "ffmpeg-fixietf", "ffmpeg-tags", "mkvmerge", "mkvmerge-noietf",
+                    "artificial-container",
+                ]  # fmt: skip
+            else:
+                ladder = [
+                    "mkvmerge", "mkvmerge-noietf", "ffmpeg-fixietf", "ffmpeg", "ffmpeg-tags",
+                    "artificial-container",
+                ]  # fmt: skip
         else:
             ladder = ["ffmpeg"]
 

--- a/RegressionTests/reduction-rules.example.json
+++ b/RegressionTests/reduction-rules.example.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "_comment": "Example media-specific reduction rules. The real file lives WITH the corpus (never in source control) so private filenames stay out of the repo. reduce_corpus.py reads the 'regions' map; locate_issue.py --write-rules generates entries by locating a decode signature in the source. Keys are source basenames as they appear in the corpus catalog.json; the names below are synthetic placeholders.",
+  "_comment": "Example media-specific reduction rules. The real file lives WITH the corpus (never in source control) so private filenames stay out of the repo. reduce_corpus.py reads 'regions' (issue-localized cut windows) and 'accept' (relaxed-acceptance overrides); locate_issue.py --write-rules generates region entries by locating a decode signature in the source. Keys are source basenames as they appear in the corpus catalog.json; the names below are synthetic placeholders.",
   "regions": {
     "Example Show - S01E01.mkv": {
       "start": 540,
@@ -11,6 +11,17 @@
       "start": 1810,
       "end": 1890,
       "note": "interlaced-decode error near the 30m mark"
+    }
+  },
+  "accept": {
+    "_comment": "Relaxed acceptance. A clip whose issues reproduce but whose processing State/detections diverge from the source by a KNOWN, benign amount (a downstream artifact of a repair that depends on full-file content, not the defect itself) still passes, instead of keeping the whole source. 'method' names the exact ladder rung the override applies to; the four *_missing/*_extra sets bound the tolerated delta - a clip is accepted only when its shortfall stays within them. Any state the clip GAINS must be listed in state_extra; anything it fails to reproduce, in state_missing / detections_missing / signatures_missing. (Artificial-container needs no entry here: it is a normal ladder rung that either reproduces a renamed-MP4 source cleanly or is rejected by the strict gate.)",
+    "Example Deep-Repair Show - S02E03.mkv": {
+      "method": "ffmpeg-fixietf",
+      "state_missing": ["ReMuxed"],
+      "state_extra": [],
+      "detections_missing": [],
+      "signatures_missing": [],
+      "note": "the source's remux is a downstream artifact of a full-file setts repair; the 60s clip reproduces the core repair (Repaired, Verified) but not the remux"
     }
   }
 }

--- a/RegressionTests/reduction-rules.example.json
+++ b/RegressionTests/reduction-rules.example.json
@@ -14,7 +14,7 @@
     }
   },
   "accept": {
-    "_comment": "Relaxed acceptance. A clip whose issues reproduce but whose processing State/detections diverge from the source by a KNOWN, benign amount (a downstream artifact of a repair that depends on full-file content, not the defect itself) still passes, instead of keeping the whole source. 'method' names the exact ladder rung the override applies to; the four *_missing/*_extra sets bound the tolerated delta - a clip is accepted only when its shortfall stays within them. Any state the clip GAINS must be listed in state_extra; anything it fails to reproduce, in state_missing / detections_missing / signatures_missing. (Artificial-container needs no entry here: it is a normal ladder rung that either reproduces a renamed-MP4 source cleanly or is rejected by the strict gate.)",
+    "_comment": "Relaxed acceptance. A clip whose issues reproduce but whose processing State, detections, or verify-error signatures diverge from the source by a KNOWN, benign amount (a downstream artifact of a repair that depends on full-file content, not the defect itself) still passes, instead of keeping the whole source. 'method' names the exact ladder rung the override applies to; the three *_missing sets plus state_extra bound the tolerated delta - a clip is accepted only when its shortfall stays within them. Any state the clip GAINS must be listed in state_extra; anything it fails to reproduce, in state_missing / detections_missing / signatures_missing. (Artificial-container needs no entry here: it is a normal ladder rung that either reproduces a renamed-MP4 source cleanly or is rejected by the strict gate.)",
     "Example Deep-Repair Show - S02E03.mkv": {
       "method": "ffmpeg-fixietf",
       "state_missing": ["ReMuxed"],


### PR DESCRIPTION
## What

Makes the reduced regression corpus regenerable from scratch for **every** curated file. Two localized-defect samples could previously only be reproduced by one-shot steps that lived outside the committed tooling, so a clean `reduce_corpus.py` run fell back to keeping them whole (~13 GB). This ports both into the tool:

- **`artificial-container`** — a last-resort ladder rung that re-muxes the head with the MP4 muxer under the `.mkv` name, reproducing a source that IS a renamed MP4. It sits after every real MKV cutter, so a genuine MKV never reaches it (and the prove-equivalence gate would reject it if it did).
- **Relaxed acceptance** — data-driven, from the external rules file. Some samples reproduce their defect but diverge from the source by a *known, benign* amount — a downstream artifact of a full-file repair that a 60s clip cannot trigger. An `accept` entry declares the exact, bounded State/detection delta tolerated for a **named rung**; a clip within that bound passes as `relaxed` and the catalog records the delta (`relaxed` + `state_delta`) so the divergence stays explicit rather than looking like a clean match.

## Why

The region windows and these two methods were the last pieces of the reduced-corpus process that were not reproducible from the committed tooling alone. Keeping the divergences **in data** (the external `reduction-rules.json` that lives with the media) preserves the copyright-safety rule — no private filenames enter the tree — while closing the from-scratch-regen gap.

## Copyright safety

No media filenames added to the repo. `artificial-container` needs no per-file data. The relaxed-acceptance overrides are keyed by basename in the external rules file that lives *with the corpus*; the repo ships only synthetic placeholders in `reduction-rules.example.json`.

## Validation

- `ruff check` / `ruff format --check` / `mypy` clean (pinned CI versions, via Docker).
- `markdownlint-cli2` clean on the README.
- End-to-end: a from-scratch validate over the full corpus reduces every curated file with no unexpected kept-full fallback (the 6 region files, the renamed-MP4 sample via `artificial-container`, and the two relaxed samples all pass). Deltas encoded in the rules file are measured against the current PlexCleaner image, not hand-authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)