### PR TITLE
Add per-file partial-credit progress to the runtime metrics

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,17 +6,17 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 
 - Version 3.22:
   - Added always-on runtime metrics published via `System.Diagnostics.Metrics` under the `PlexCleaner.Process` meter, readable with `dotnet-counters` with no extra infrastructure.
-    - Overall progress is weighted by input bytes rather than file count, so a run mixing tiny and huge files reports the actual work completed. In this first version an in-flight file contributes no partial credit until it finishes.
+    - Overall progress is weighted by input bytes rather than file count, so a run mixing tiny and huge files reports the actual work completed, and it advances smoothly during a long operation because each in-flight file contributes partial credit from the running tool (the full-file scan, the re-encode, and the deinterlace).
     - Instruments include the run file and byte totals, in-flight and active-thread counts, completed bytes, the weighted `progress.ratio` and `eta.seconds`, cumulative per-outcome counters (completed, modified, errors, verify-failed, and a per-`State`-flag tally), and the `file.duration` and per-tool `tool.duration` histograms. Metrics are aggregate only, with bounded `state` and `tool` tags and no filename tags.
     - The run-scoped gauges reset at the start of every processing pass, so monitor mode and back-to-back commands each report their own run, while the counters stay cumulative for rate display.
     - Instruments are inert until a listener observes them, so the feature is always on with no configuration flag and negligible idle overhead.
-    - The Docker image ships a `counters` wrapper, so reading the metrics is `docker exec <container> counters`.
+    - The meter is OpenTelemetry and `dotnet-monitor` compatible, and the Docker image ships a `counters` wrapper, so reading the metrics is `docker exec <container> counters`.
 - Version 3.21:
   - Repair non-monotonic DTS muxer warnings losslessly instead of failing repair permanently.
     - `ffmpeg -f null` can exit `0` yet emit `Application provided invalid, non monotonically increasing dts to muxer` for files that may decode and play correctly.
     - The previous "any stderr means failure" rule promoted this muxer-interleaving artifact to a hard `VerifyFailed`/`RepairFailed`, and a re-encode could not fix it because Matroska stores no DTS and ffmpeg re-derives a non-monotonic timeline on read.
     - Verify now classifies the decode diagnostics deterministically as clean, a timestamp-only failure, or a decode error; a timestamp-only failure is a repairable failure and everything else fails (fail-closed, so an unrecognized diagnostic fails as a decode error).
-    - The classification streams the output line by line, so memory stays bounded even when a file emits a warning per packet ([#827](https://github.com/ptr727/PlexCleaner/issues/827)).
+    - The classification streams the output line by line, so memory stays bounded even when a file emits a warning per packet ([#827][issue-827-link]).
   - Added a lossless timestamp repair as the first repair tier, escalating to remux and re-encode when it cannot apply.
     - When verification detects a demux-visible non-monotonic DTS on an audio stream, the audio packet timestamps are rewritten to be strictly monotonic using the `setts` bitstream filter with a stream copy (no re-encode), then re-verified.
     - A regression gate compares the per-stream coded payload hash and the per-stream start and duration before and after, discarding the result unless every stream is byte-identical and no stream shifted beyond the A/V-sync tolerance, so the lossless repair can neither alter the media nor drift the audio out of sync.
@@ -45,7 +45,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
   - Log a warning when a repair or cleanup condition is detected (redundant `Default` flags, invalid language tags, interlaced video, tracks needing re-encode, etc.) so `--loglevel Warning` surfaces every file that is modified; enable `--logelevate` to also see the subsequent cleanup steps for those files.
   - Always log the end-of-run summary regardless of the configured log level, so the modified, error, and verify-failed counts are recorded for every processing run.
   - Fixed a defect in `idet` interlace detection, beyond the logging changes: ffmpeg can emit its idet statistics more than once (an early empty pass before the final cumulative counts), which could cause the counts to parse incorrectly and the interlace detection operation to fail; the parser now matches every emitted statistics block and uses the final cumulative counts.
-  - Improved interlace detection reporting: `FindInterlacedTracks` is now a pure predicate that surfaces how interlacing was detected (idet scan versus container metadata flag), the interlaced verdict and its human-readable justification are encapsulated in a self-describing reason string, and dead idet reporting code that never fed the decision was removed ([#809](https://github.com/ptr727/PlexCleaner/issues/809), [#810](https://github.com/ptr727/PlexCleaner/issues/810)).
+  - Improved interlace detection reporting: `FindInterlacedTracks` is now a pure predicate that surfaces how interlacing was detected (idet scan versus container metadata flag), the interlaced verdict and its human-readable justification are encapsulated in a self-describing reason string, and dead idet reporting code that never fed the decision was removed ([#809][issue-809-link], [#810][issue-810-link]).
   - Handle the `SIGINT`, `SIGTERM`, and `SIGQUIT` termination signals (`docker stop`, `Ctrl+C`) so processing is interrupted gracefully and the summary and exit code are logged before exit. The custom `Ctrl+Q`/`Ctrl+Z` exit keys are removed in favor of the standard signals.
   - Normalize `Default` track flags instead of only warning about them: clear the flag on a lone track of a type, keep the preferred audio track as the single default when multiple are flagged, and clear all default flags on subtitle tracks.
   - Added a `custom` command that loads a user-provided plugin assembly implementing `IProcessPlugin` and runs it over the media files, reusing the file iteration and processing API for bespoke re-processing or repair. Includes the `MatroskaHeaderCleanup` example plugin. Not available in AOT builds.
@@ -54,14 +54,14 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
   - Reworked the CI/CD pipeline to a branch-scoped self-publishing model: a weekly scheduled run (and manual dispatch) publishes both `main` (stable, Docker `latest`) and `develop` (prerelease, Docker `develop`) - native executables, the multi-arch Docker image, and the GitHub release - while merges accumulate until the next run. No application changes.
   - Added `WORKFLOW.md` (the canonical CI/CD specification) and `repo-config/` (rulesets and repository settings as code).
 - Version 3.18:
-  - Fixed an infinite remux loop in `monitor` mode on files with unmappable IETF / BCP-47 language tags ([#747](https://github.com/ptr727/PlexCleaner/issues/747)).
+  - Fixed an infinite remux loop in `monitor` mode on files with unmappable IETF / BCP-47 language tags ([#747][issue-747-link]).
     - Invalid IETF language tags (e.g. `language_ietf` set to a value that cannot be resolved to ISO 639) are now set in place to a valid tag (the ISO 639 equivalent if known, else `und`) so the repair converges instead of remuxing the same file every cycle.
     - Added a non-convergence guard: if a repair (invalid language tags, metadata remux, or the Matroska structure check) does not resolve the detected errors, the file is marked `VerifyFailed` and is no longer re-processed, breaking the loop for any unfixable condition.
-  - Added a deterministic Direct Play verification check ([#746](https://github.com/ptr727/PlexCleaner/issues/746)).
+  - Added a deterministic Direct Play verification check ([#746][issue-746-link]).
     - Some Matroska files parse cleanly with FfProbe / MkvMerge / MediaInfo yet fail Direct Play in Jellyfin / Emby / Shield because the player cannot use the file's seek index (e.g. the Cues are positioned before the Tracks, which a forward-only reader cannot reach).
     - `Verify` now validates the Matroska seek index (the SeekHead and Cues a player needs for keyframe seeking) using the NEbml library, and remuxes only files whose index is missing or unusable, leaving valid files untouched.
-  - Quickscan accuracy: under `--quickscan` the limited sample is not representative, so interlace detection now skips the unreliable `idet` frame analysis (relying on container interlace flags only) and bitrate verification is skipped, avoiding false-positive deinterlacing of progressive content and unreliable bitrate-exceeded reports ([#749](https://github.com/ptr727/PlexCleaner/issues/749)).
-  - Interlace detection is more conservative to avoid deinterlacing progressive content: it uses idet's more reliable MultiFrame pass and the dominant field order, and only treats content as interlaced when interlaced frames outnumber progressive frames ([#749](https://github.com/ptr727/PlexCleaner/issues/749)).
+  - Quickscan accuracy: under `--quickscan` the limited sample is not representative, so interlace detection now skips the unreliable `idet` frame analysis (relying on container interlace flags only) and bitrate verification is skipped, avoiding false-positive deinterlacing of progressive content and unreliable bitrate-exceeded reports ([#749][issue-749-link]).
+  - Interlace detection is more conservative to avoid deinterlacing progressive content: it uses idet's more reliable MultiFrame pass and the dominant field order, and only treats content as interlaced when interlaced frames outnumber progressive frames ([#749][issue-749-link]).
 - Version 3.16:
   - Structural changes only, no functional changes.
   - Consolidated project structure, build configuration, CI/CD workflows, and Docker configuration across projects.
@@ -73,48 +73,48 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
 - Version 3.15:
   - This is primarily a code refactoring release.
   - Updated from .NET 9 to .NET 10.
-  - Added [Nullable types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/nullable-value-types) support.
-  - Added [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot) support.
-    - Replaced `JsonSchemaBuilder.FromType<T>()` with `GetJsonSchemaAsNode()` as `FromType<T>()` is [not AOT compatible](https://github.com/json-everything/json-everything/issues/975).
-    - Replaced `JsonSerializer.Deserialize<T>()` with `JsonSerializer.Deserialize(JsonSerializerContext)` for generating [AOT compatible](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonserializercontext) JSON serialization code.
+  - Added [Nullable types][nullable-value-types-link] support.
+  - Added [Native AOT][native-aot-link] support.
+    - Replaced `JsonSchemaBuilder.FromType<T>()` with `GetJsonSchemaAsNode()` as `FromType<T>()` is [not AOT compatible][json-everything-issue-link].
+    - Replaced `JsonSerializer.Deserialize<T>()` with `JsonSerializer.Deserialize(JsonSerializerContext)` for generating [AOT compatible][jsonserializercontext-link] JSON serialization code.
     - Replaced `MethodBase.GetCurrentMethod()?.Name` with `[System.Runtime.CompilerServices.CallerMemberName]` to generate the caller function name during compilation.
-    - AOT cross compilation is [not supported](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/cross-compile) by the CI/CD pipeline and single file native AOT binaries can be [manually built](./README.md#aot) if needed.
+    - AOT cross compilation is [not supported][native-aot-cross-compile-link] by the CI/CD pipeline and single file native AOT binaries can be [manually built](./README.md#aot) if needed.
   - Changed MediaInfo output from `--Output=XML` using XML to `--Output=JSON` using JSON.
-    - Attempts to use `Microsoft.XmlSerializer.Generator` and generate AOT compatible XML parsing was [unsuccessful](https://stackoverflow.com/questions/79858800/statically-generated-xml-parsing-code-using-microsoft-xmlserializer-generator), while JSON `JsonSerializerContext` is AOT compatible.
+    - Attempts to use `Microsoft.XmlSerializer.Generator` and generate AOT compatible XML parsing was [unsuccessful][stackoverflow-xmlserializer-link], while JSON `JsonSerializerContext` is AOT compatible.
     - Parsing the existing XML schema is done with custom AOT compatible XML parser created for the MediaInfo XML content.
     - SidecarFile schema changed from v4 to v5 to account for XML to JSON content change.
     - Schema will automatically be upgraded and convert XML to JSON equivalent on reading.
-  - Using [`ArrayPool<byte>.Shared.Rent()`](https://learn.microsoft.com/en-us/dotnet/api/system.buffers.arraypool-1) vs. `new byte[]` to improve memory pressure during sidecar hash calculations.
+  - Using [`ArrayPool<byte>.Shared.Rent()`][arraypool-link] vs. `new byte[]` to improve memory pressure during sidecar hash calculations.
   - Removed `MonitorOptions` from the config file schema, default values do not need to be changed.
-  - ⚠️ Standardized on only using the Ubuntu [rolling](https://releases.ubuntu.com/) docker base image.
+  - ⚠️ Standardized on only using the Ubuntu [rolling][ubuntu-releases-link] docker base image.
     - No longer publishing Debian or Alpine based docker images, or images supporting `linux/arm/v7`.
     - The media tool versions published with the rolling release are typically current, and matches the versions available on Windows, offering a consistent experience, and requires less testing due to changes in behavior between versions.
 - Version 3.14:
   - Switch to using [CliWrap][cliwrap-link] for commandline tool process execution.
-  - Remove dependency on [deprecated](https://github.com/dotnet/command-line-api/issues/2576) `System.CommandLine.NamingConventionBinder` by directly using commandline options binding.
+  - Remove dependency on [deprecated][command-line-api-issue-2576-link] `System.CommandLine.NamingConventionBinder` by directly using commandline options binding.
   - Converted media tool commandline creation to using fluent builder pattern.
   - Converted FFprobe JSON packet parsing to using streaming per-packet processing using [Utf8JsonAsyncStreamReader][utf8jsonasync-link] vs. read everything into memory and then process.
   - Switched editorconfig `charset` from `utf-8-bom` to `utf-8` as some tools and PR merge in GitHub always write files without the BOM.
   - Improved closed caption detection in MediaInfo, e.g. discrete detection of separate `SCTE 128` tracks vs. `A/53` embedded video tracks.
   - Improved media tool parsing resiliency when parsing non-Matroska containers, i.e. added `testmediainfo` command to attempt parsing media files.
-  - Add [Husky.Net](https://alirezanet.github.io/Husky.Net) for pre-commit hook code style validation.
+  - Add [Husky.Net][husky-link] for pre-commit hook code style validation.
   - General refactoring.
 - Version 3.13:
-  - Escape additional filename characters for use with `ffprobe movie=filename[out0+subcc]` command. Fixes [#524](https://github.com/ptr727/PlexCleaner/issues/524).
+  - Escape additional filename characters for use with `ffprobe movie=filename[out0+subcc]` command. Fixes [#524][issue-524-link].
 - Version 3:12:
   - Update to .NET 9.0.
     - ⚠️ Dropping Ubuntu docker `arm/v7` support as .NET for ARM32 is no longer published in the Ubuntu repository.
     - Switching Debian docker builds to install .NET using install script as the Microsoft repository now only supports x64 builds. (Ubuntu and Alpine still installing .NET using the distribution repository.)
     - Updated code style [`.editorconfig`](./.editorconfig) to closely follow the Visual Studio and .NET Runtime defaults.
-    - Set [CSharpier](https://csharpier.com/) as default C# code formatter.
+    - Set [CSharpier][csharpier-link] as default C# code formatter.
   - ⚠️ Removed docker [`UbuntuDevel.Dockerfile`](./Docker/Ubuntu.Devel.Dockerfile), [`AlpineEdge.Dockerfile`](./Docker/Alpine.Edge.Dockerfile), and [`DebianTesting.Dockerfile`](./Docker/Debian.Testing.Dockerfile) builds from CI as theses OS pre-release / Beta builds were prone to intermittent build failures. If "bleeding edge" media tools are required local builds can be done using the Dockerfile.
   - Updated 7-Zip version number parsing to account for newly [observed](./PlexCleanerTests/VersionParsingTests.cs) variants.
-  - EIA-608 and CTA-708 closed caption detection was reworked due to FFmpeg [removing](https://code.ffmpeg.org/FFmpeg/FFmpeg/commit/19c95ecbff84eebca254d200c941ce07868ee707) easy detection using FFprobe.
+  - EIA-608 and CTA-708 closed caption detection was reworked due to FFmpeg [removing][ffmpeg-commit-link] easy detection using FFprobe.
     - See the [EIA-608 and CTA-708 Closed Captions](./README.md#eia-608-and-cta-708-closed-captions) section for details.
     - Refactored the logic used to determine if a video stream should be considered to contain closed captions.
     - Detection may have been broken since the release of FFmpeg v7, it is possible that media files may be in the `Verified` state with closed captions being undetected, run the `removeclosedcaptions` command to re-detect and remove closed captions.
   - Interlace and Telecine detection is complicated and this implementation using track flags and `idet` is naive and may not be reliable, changed `DeInterlace` to default to `false`.
-  - Re-added `parallel` and `threadcount` option to `monitor` command, fixes [#498](https://github.com/ptr727/PlexCleaner/issues/498).
+  - Re-added `parallel` and `threadcount` option to `monitor` command, fixes [#498][issue-498-link].
   - Added conditional checks for `ReMux` to warn when disabled and media must be modified for processing logic to work as intended, e.g. removing extra video streams, removing cover art, etc.
   - Added `quickscan` option to limit the scan duration and improve performance, at the potential cost of accuracy.
   - When `parallel` is enabled and `threadcount` is not specified, cap the default of 1/2 CPU cores to max 4, and cap set value to CPU count, prevents CPU starvation.
@@ -133,19 +133,19 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
     - If "bleeding edge" media tools are required consider using `ubuntu-devel` (based on `ubuntu:devel`), `alpine-edge` (based on `alpine:edge`) or `debian-testing` (based on `debian:testing-slim`) tags.
     - If you are currently using the `ptr727/plexcleaner:savoury` docker tag, please switch to `ptr727/plexcleaner:ubuntu`.
 - Version 3.9:
-  - Re-enabling Alpine Stable builds now that Alpine 3.20 has been [released](https://alpinelinux.org/posts/Alpine-3.20.0-released.html).
-  - No longer pre-installing VS Debug Tools in docker builds, replaced with [`DebugTools.sh`](./Docker//DebugTools.sh) script that can be used to install [VS Debug Tools](https://learn.microsoft.com/en-us/visualstudio/debugger/remote-debugging-dotnet-core-linux-with-ssh) and [.NET Diagnostic Tools](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/tools-overview) if required.
+  - Re-enabling Alpine Stable builds now that Alpine 3.20 has been [released][alpine-release-link].
+  - No longer pre-installing VS Debug Tools in docker builds, replaced with [`DebugTools.sh`](./Docker//DebugTools.sh) script that can be used to install [VS Debug Tools][remote-debugging-link] and [.NET Diagnostic Tools][dotnet-diagnostics-link] if required.
 - Version 3.8:
   - Added Alpine Stable and Edge, Debian Stable and Testing, and Ubuntu Rolling and Devel docker builds.
   - ⚠️ Removed ArchLinux docker build, only supported x64 and media tool versions were often lagging.
   - No longer using MCR base images with .NET pre-installed, support for new linux distribution versions were often lagging.
-  - Alpine Stable builds are still [disabled](https://github.com/ptr727/PlexCleaner/issues/344), waiting for Alpine 3.20 to be released, ETA 1 June 2024.
+  - Alpine Stable builds are still [disabled][issue-344-link], waiting for Alpine 3.20 to be released, ETA 1 June 2024.
   - Rob Savoury [announced][savoury-link] that due to a lack of funding Ubuntu Noble 24.04 LTS will not get PPA support.
     - Pinning `savoury` docker builds to Jammy 22.04 LTS.
     - Switching `latest` docker tag from `savoury` to an alias for `ubuntu` builds, i.e. the latest released version of Ubuntu, currently Noble 24.04 LTS.
   - Updated `savoury` docker builds to FfMpeg v7, currently the only docker build supporting FfMpeg v7.
 - Version 3.7:
-  - Added `ProcessOptions:FileIgnoreMasks` to support skipping (not deleting) sample files per [discussions request](https://github.com/ptr727/PlexCleaner/discussions/341).
+  - Added `ProcessOptions:FileIgnoreMasks` to support skipping (not deleting) sample files per [discussions request][discussion-341-link].
     - Wildcard characters `*` and `?` are supported, e.g. `*.sample` or `*.sample.*`.
     - Wildcard support now also allows excluding temporary UnRaid FuseFS files, e.g. `*.fuse_hidden*`.
   - Settings JSON schema changed from v3 to v4.
@@ -154,23 +154,23 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
     - `ConvertOptions:FfMpegOptions:Output` has been deprecated, no need for user configurable values.
     - `ConvertOptions:FfMpegOptions:Global` no longer requires defaults values and will only be used during encoding, only add custom values for e.g. hardware acceleration, existing values will be converted.
       - E.g. `-analyzeduration 2147483647 -probesize 2147483647 -hwaccel cuda -hwaccel_output_format cuda` will be converted to `-hwaccel cuda -hwaccel_output_format cuda`.
-  - Changed JSON serialization from `Newtonsoft.Json` [to](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/migrate-from-newtonsoft) .NET native `Text.Json`.
+  - Changed JSON serialization from `Newtonsoft.Json` [to][migrate-from-newtonsoft-link] .NET native `Text.Json`.
   - Changed JSON schema generation from `Newtonsoft.Json.Schema` [to][jsonschema-link] `JsonSchema.Net.Generation`.
   - Fixed issue with old settings schemas not upgrading as expected, and updated associated unit tests to help catch this next time.
-  - ⚠️ Disabling Alpine Edge builds, Handbrake is [failing](https://gitlab.alpinelinux.org/alpine/aports/-/issues/15979) to install, again.
+  - ⚠️ Disabling Alpine Edge builds, Handbrake is [failing][alpine-issue-15979-link] to install, again.
     - Will re-enable Alpine builds if Alpine 3.20 and Handbrake is stable.
 - Version 3.6:
   - Disabling Alpine 3.19 release builds and switching to Alpine Edge.
-    - Handbrake is only available on Edge, and mixing released and Edge versions cause too many [issues](https://gitlab.alpinelinux.org/alpine/aports/-/issues/15949).
+    - Handbrake is only available on Edge, and mixing released and Edge versions cause too many [issues][alpine-issue-15949-link].
     - Alpine stable release builds will no longer be built, or not until Handbrake is supported on stable releases (v3.20 May 2024).
     - Alpine Edge builds will be tagged as `alpine-edge`.
 - Version 3.5:
-  - Download 7-Zip builds from [GitHub](https://github.com/ip7z/7zip/releases), fixes [#324](https://github.com/ptr727/PlexCleaner/issues/324).
+  - Download 7-Zip builds from [GitHub][sevenzip-releases-link], fixes [#324][issue-324-link].
   - Update Alpine Docker image to 3.19.
 - Version 3.4:
-  - Updated to [.NET 8.0](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8).
+  - Updated to [.NET 8.0][dotnet-8-link].
   - Updated Debian Docker image to Bookworm.
-  - Warn when a newer [GitHub Release](https://github.com/ptr727/PlexCleaner/releases/latest) version is available.
+  - Warn when a newer [GitHub Release][releases-latest-link] version is available.
     - Only tests for new release availability if `ToolsOptions:AutoUpdate` is enabled.
     - Updating the tool itself is still a manual process.
     - Alternatively subscribe to GitHub [Release Notifications][github-release-notification].
@@ -178,8 +178,8 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
     - Only media stream validation is performed, track-, bitrate-, and HDR verification is only performed as part of the `process` command.
     - The `verify` command is useful when testing or selecting from multiple available media sources.
 - Version 3.3:
-  - Download Windows FfMpeg builds from [GyanD FfMpeg GitHub mirror](https://github.com/GyanD/codexffmpeg), may help with [#214](https://github.com/ptr727/PlexCleaner/issues/214).
-  - Install Alpine media tools from `latest-stable` to match the v3.18 base image version, resolves [MediaInfo segfault](https://github.com/ptr727/PlexCleaner/issues/208).
+  - Download Windows FfMpeg builds from [GyanD FfMpeg GitHub mirror][codexffmpeg-link], may help with [#214][issue-214-link].
+  - Install Alpine media tools from `latest-stable` to match the v3.18 base image version, resolves [MediaInfo segfault][issue-208-link].
   - Add "legacy" `osx.13-arm64` build.
   - Make Rider 2023.2.1 happy with current C# linter rules.
 - Version 3.2:
@@ -199,22 +199,22 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
     - Removed the `ConvertOptions:EnableH265Encoder`, `ConvertOptions:VideoEncodeQuality` and `ConvertOptions:AudioEncodeCodec` options.
     - Replaced with `ConvertOptions:FfMpegOptions` and `ConvertOptions:HandBrakeOptions` options.
     - On v3 schema upgrade old `ConvertOptions` settings will be upgrade to equivalent settings.
-  - Added support for [IETF / RFC 5646 / BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) language tag formats.
+  - Added support for [IETF / RFC 5646 / BCP 47][ietf-language-tag-link] language tag formats.
     - See the [Language Matching](./README.md#language-matching) section usage for details.
-    - IETF language tags allows for greater flexibility in Matroska player [language matching](https://codeberg.org/mbunkus/mkvtoolnix/wiki/Languages-in-Matroska-and-MKVToolNix).
+    - IETF language tags allows for greater flexibility in Matroska player [language matching][mkvtoolnix-languages-link].
       - E.g. `pt-BR` for Brazilian Portuguese vs. `por` for Portuguese.
       - E.g. `zh-Hans` for simplified Chinese vs. `chi` for Chinese.
     - Update `ProcessOptions:DefaultLanguage` and `ProcessOptions:KeepLanguages` from ISO 639-2B to RFC 5646 format, e.g. `eng` to `en`.
       - On v3 schema upgrade old ISO 639-2B 3 letter tags will be replaced with generic RFC 5646 tags.
     - Added `ProcessOptions.SetIetfLanguageTags` to conditionally remux files using MkvMerge to apply IETF language tags when not set.
       - When enabled all files without IETF tags will be remuxed in order to set IETF language tags, this could be time consuming on large collections of older media that lack the now common IETF tags.
-    - [FFmpeg](https://github.com/ptr727/PlexCleaner/issues/148) and [HandBrake](https://github.com/ptr727/PlexCleaner/issues/149) removes IETF language tags.
+    - [FFmpeg][issue-148-link] and [HandBrake][issue-149-link] removes IETF language tags.
       - Files are remuxed using MkvMerge, and IETF tags are restored using MkvPropEdit, after any FFmpeg or HandBrake operation.
       - If you care and can, please do communicate the need for IETF language support to the FFmpeg and HandBrake development teams.
     - Added warnings and attempt to repair when the Language and LanguageIetf are set and are invalid or do not match.
     - `MkvMerge --identify` added the `--normalize-language-ietf extlang` option to report e.g. `zh-cmn-Hant` vs. `cmn-Hant`.
       - Existing sidecar metadata can be updated using the `updatesidecar` command.
-  - Added `ProcessOptions:KeepOriginalLanguage` to keep tracks marked as [original language](https://www.ietf.org/archive/id/draft-ietf-cellar-matroska-15.html#name-original-flag).
+  - Added `ProcessOptions:KeepOriginalLanguage` to keep tracks marked as [original language][matroska-original-flag-link].
   - Added `ProcessOptions:RemoveClosedCaptions` to conditionally vs. always remove closed captions.
   - Added `ProcessOptions:SetTrackFlags` to set track flags based on track title keywords, e.g. `SDH` -> `HearingImpaired`.
   - Added `createschema` command to create the settings JSON schema file, no longer need to use `Sandbox` project to create the schema file.
@@ -228,7 +228,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
   - Updated cover art detection and removal logic to not be dependent on `RemoveTags` setting.
   - Updated `DeleteInvalidFiles` logic to delete any file that fails processing, not just files that fail verification.
   - Updated `RemoveDuplicateLanguages` logic to use MkvMerge IETF language tags.
-  - Updated `RemoveDuplicateTracks` logic to account for Matroska [track flags](https://www.ietf.org/archive/id/draft-ietf-cellar-matroska-15.html#name-track-flags).
+  - Updated `RemoveDuplicateTracks` logic to account for Matroska [track flags][matroska-track-flags-link].
   - Refactored JSON schema versioning logic to use `record` instead of `class` allowing for derived classes to inherited attributes vs. needing to duplicate all attributes.
   - Refactored track selection logic to simplify containment and use with lambda filters.
   - Refactored verify and repair logic, became too complicated.
@@ -240,7 +240,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
     - Older settings schemas will automatically be upgraded with compatible settings to v3 on first run.
   - ⚠️ Removed the `reprocess` commandline option, logic was very complex with limited value, use `reverify` instead.
   - ⚠️ Refactored commandline arguments to only add relevant options to commands that use them vs. adding global options to all commands.
-    - Maintaining commandline backwards compatibility was [complicated](https://github.com/dotnet/command-line-api/issues/2023), and the change is unfortunately a breaking change.
+    - Maintaining commandline backwards compatibility was [complicated][command-line-api-issue-2023-link], and the change is unfortunately a breaking change.
     - The following global options have been removed and added to their respective commands:
       - `--settingsfile` used by several commands.
       - `--parallel` used by the `process` command.
@@ -257,9 +257,9 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
     - As with the `--reprocess` option, this option is useful when the tooling changed, and may now be better equipped to verify or repair broken media.
 - Version 2.9:
   - Added remote docker container debug support.
-    - `develop` tagged docker builds use the `Debug` build target, and will now install the .NET SDK and the [VsDbg](https://aka.ms/getvsdbgsh) .NET Debugger.
+    - `develop` tagged docker builds use the `Debug` build target, and will now install the .NET SDK and the [VsDbg][vsdbg-link] .NET Debugger.
     - Added a `--debug` command line option that will wait for a debugger to be attached on launch.
-    - Remote debugging in docker over SSH can be done using [VSCode](https://github.com/OmniSharp/omnisharp-vscode/wiki/Attaching-to-remote-processes) or [Visual Studio](https://docs.microsoft.com/en-us/visualstudio/debugger/attach-to-process-running-in-docker-container?view=vs-2022).
+    - Remote debugging in docker over SSH can be done using [VSCode][omnisharp-remote-link] or [Visual Studio][vs-docker-debug-link].
   - Updated Dockerfile with latest Linux install steps for MediaInfo and MKVToolNix.
   - Updated System.CommandLine usage to accommodate Beta 4 breaking changes.
 - Version 2.8:
@@ -279,7 +279,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
   - Fixed verify and repair logic when `VerifyOptions:AutoRepair` is enabled and file is in `VerifyFailed` state but not `RepairFailed`, could happen when processing is interrupted.
   - Silenced the noisy `tool version mismatch` warnings when `ProcessOptions:SidecarUpdateOnToolChange` is disabled.
   - Replaced `FileEx.IsFileReadWriteable()` with `!FileInfo.IsReadOnly` to optimize for speed over accuracy, testing for attributes vs. opening for write access.
-  - Pinned docker base image to `ubuntu:focal` vs. `ubuntu:latest` until Handbrake PPA ads support for Jammy, tracked as [#98](https://github.com/ptr727/PlexCleaner/issues/98).
+  - Pinned docker base image to `ubuntu:focal` vs. `ubuntu:latest` until Handbrake PPA ads support for Jammy, tracked as [#98][issue-98-link].
 - Version 2.6:
   - Fixed `SidecarFile.Update()` bug that would not update the sidecar when only the `State` changed, and kept re-verifying the same verified files.
   - Added a `--reprocess` option to the `process` command, `process --reprocess [0 (default), 1, 2]`
@@ -288,14 +288,14 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
     - 1: Re-process low cost operations, e.g. tag detection, closed caption detection, etc.
     - 2: Re-process all operations including expensive operations, e.g. deinterlace detection, bitrate calculation, stream verification, etc.
     - Whenever processing logic is updated or improved (e.g. this release), it is recommended to run with `--reprocess 1` at least once.
-  - Added workaround for HandBrake that [force converts](https://github.com/HandBrake/HandBrake/issues/160) closed captions and subtitle tracks to `ASS` format.
+  - Added workaround for HandBrake that [force converts][handbrake-issue-link] closed captions and subtitle tracks to `ASS` format.
     - After HandBrake deinterlacing, the original subtitles are added to the output file, bypassing HandBrake subtle logic.
     - Subtitle track formats and attributes are preserved, and closed captions embedded are not converted to subtitle tracks.
-    - The HandBrake issue tracked as [#95](https://github.com/ptr727/PlexCleaner/issues/95).
-  - Added the removal of [EIA-608](https://en.wikipedia.org/wiki/EIA-608) Closed Captions from video streams.
+    - The HandBrake issue tracked as [#95][issue-95-link].
+  - Added the removal of [EIA-608][eia-608-link] Closed Captions from video streams.
     - Closed Caption subtitles in video streams are undesired as they cannot be managed, all subtitles should be in discrete tracks.
-    - FFprobe [fails](https://www.mail-archive.com/ffmpeg-devel@ffmpeg.org/msg126211.html) to set the `closed_captions` JSON attribute in JSON output mode, but does detect and print `Closed Captions` in normal output mode.
-    - FFprobe issue tracked as [#94](https://github.com/ptr727/PlexCleaner/issues/94).
+    - FFprobe [fails][ffmpeg-devel-link] to set the `closed_captions` JSON attribute in JSON output mode, but does detect and print `Closed Captions` in normal output mode.
+    - FFprobe issue tracked as [#94][issue-94-link].
   - Added the ability to bootstrap 7-Zip downloads on Windows, manually downloading `7za.exe` is no longer required.
     - Getting started is now easier, just run:
       - `PlexCleaner.exe --settingsfile PlexCleaner.json defaultsettings`
@@ -316,7 +316,7 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
     - Use `process --reprocess 2` instead.
   - Minor code cleanup and improvements.
 - Version 2.5:
-  - Changed the config file JSON schema to simplify authoring of multi-value settings, resolves [#85](https://github.com/ptr727/PlexCleaner/issues/85)
+  - Changed the config file JSON schema to simplify authoring of multi-value settings, resolves [#85][issue-85-link]
     - Older file schemas will automatically be upgraded without requiring user input.
     - Comma separated lists in string format converted to array of strings.
       - Old: `"ReMuxExtensions": ".avi,.m2ts,.ts,.vob,.mp4,.m4v,.asf,.wmv,.dv",`
@@ -327,10 +327,10 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
         - `"ReEncodeVideoCodecs": "*,dx50,div3,mp42,*,*,*,*,*,*"`
         - `"ReEncodeVideoProfiles": "*,*,*,*,*,Constrained Baseline@30,*,*,*,*"`
       - New: `"ReEncodeVideo": [ { "Format": "mpeg2video" }, { "Format": "mpeg4", "Codec": "dx50" }, ... ]`
-  - Replaced [GitVersion](https://github.com/GitTools/GitVersion) with [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) as versioning tool, resolves [#16](https://github.com/ptr727/PlexCleaner/issues/16).
+  - Replaced [GitVersion][gitversion-link] with [Nerdbank.GitVersioning][nerdbank-gitversioning-link] as versioning tool, resolves [#16][issue-16-link].
     - Main branch will now build using `Release` configuration, other branches will continue building with `Debug` configuration.
     - Prerelease builds are now posted to GitHub releases tagged as `pre-release`, Docker builds continue to be tagged as `develop`.
-  - Docker builds are now also pushed to [GitHub Container Registry](https://github.com/ptr727/PlexCleaner/pkgs/container/plexcleaner).
+  - Docker builds are now also pushed to [GitHub Container Registry][ghcr-link].
     - Builds will continue to push to Docker Hub while it remains free to use.
   - Added a xUnit unit test project.
     - Currently the only tests are for config and sidecar JSON schema backwards compatibility.
@@ -391,9 +391,68 @@ Utility to optimize media files for Direct Play in Plex, Emby, Jellyfin, etc.
   - File logging and console output is now done using structured Serilog logging.
     - Basic console and file logging options are used, configuration from JSON is not currently supported.
 
-[cliwrap-link]: https://github.com/Tyrrrz/CliWrap
+<!-- Internal -->
+[discussion-341-link]: https://github.com/ptr727/PlexCleaner/discussions/341
 [docker-link]: https://hub.docker.com/r/ptr727/plexcleaner
+[ghcr-link]: https://github.com/ptr727/PlexCleaner/pkgs/container/plexcleaner
+[issue-148-link]: https://github.com/ptr727/PlexCleaner/issues/148
+[issue-149-link]: https://github.com/ptr727/PlexCleaner/issues/149
+[issue-16-link]: https://github.com/ptr727/PlexCleaner/issues/16
+[issue-208-link]: https://github.com/ptr727/PlexCleaner/issues/208
+[issue-214-link]: https://github.com/ptr727/PlexCleaner/issues/214
+[issue-324-link]: https://github.com/ptr727/PlexCleaner/issues/324
+[issue-344-link]: https://github.com/ptr727/PlexCleaner/issues/344
+[issue-498-link]: https://github.com/ptr727/PlexCleaner/issues/498
+[issue-524-link]: https://github.com/ptr727/PlexCleaner/issues/524
+[issue-746-link]: https://github.com/ptr727/PlexCleaner/issues/746
+[issue-747-link]: https://github.com/ptr727/PlexCleaner/issues/747
+[issue-749-link]: https://github.com/ptr727/PlexCleaner/issues/749
+[issue-809-link]: https://github.com/ptr727/PlexCleaner/issues/809
+[issue-810-link]: https://github.com/ptr727/PlexCleaner/issues/810
+[issue-827-link]: https://github.com/ptr727/PlexCleaner/issues/827
+[issue-85-link]: https://github.com/ptr727/PlexCleaner/issues/85
+[issue-94-link]: https://github.com/ptr727/PlexCleaner/issues/94
+[issue-95-link]: https://github.com/ptr727/PlexCleaner/issues/95
+[issue-98-link]: https://github.com/ptr727/PlexCleaner/issues/98
+[releases-latest-link]: https://github.com/ptr727/PlexCleaner/releases/latest
+
+<!-- External -->
+[alpine-issue-15949-link]: https://gitlab.alpinelinux.org/alpine/aports/-/issues/15949
+[alpine-issue-15979-link]: https://gitlab.alpinelinux.org/alpine/aports/-/issues/15979
+[alpine-release-link]: https://alpinelinux.org/posts/Alpine-3.20.0-released.html
+[arraypool-link]: https://learn.microsoft.com/en-us/dotnet/api/system.buffers.arraypool-1
+[cliwrap-link]: https://github.com/Tyrrrz/CliWrap
+[codexffmpeg-link]: https://github.com/GyanD/codexffmpeg
+[command-line-api-issue-2023-link]: https://github.com/dotnet/command-line-api/issues/2023
+[command-line-api-issue-2576-link]: https://github.com/dotnet/command-line-api/issues/2576
+[csharpier-link]: https://csharpier.com/
+[dotnet-8-link]: https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8
+[dotnet-diagnostics-link]: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/tools-overview
+[eia-608-link]: https://en.wikipedia.org/wiki/EIA-608
+[ffmpeg-commit-link]: https://code.ffmpeg.org/FFmpeg/FFmpeg/commit/19c95ecbff84eebca254d200c941ce07868ee707
+[ffmpeg-devel-link]: https://www.mail-archive.com/ffmpeg-devel@ffmpeg.org/msg126211.html
 [github-release-notification]: https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/managing-subscriptions-for-activity-on-github/viewing-your-subscriptions
+[gitversion-link]: https://github.com/GitTools/GitVersion
+[handbrake-issue-link]: https://github.com/HandBrake/HandBrake/issues/160
+[husky-link]: https://alirezanet.github.io/Husky.Net
+[ietf-language-tag-link]: https://en.wikipedia.org/wiki/IETF_language_tag
+[json-everything-issue-link]: https://github.com/json-everything/json-everything/issues/975
 [jsonschema-link]: https://json-everything.net/json-schema/
+[jsonserializercontext-link]: https://learn.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonserializercontext
+[matroska-original-flag-link]: https://www.ietf.org/archive/id/draft-ietf-cellar-matroska-15.html#name-original-flag
+[matroska-track-flags-link]: https://www.ietf.org/archive/id/draft-ietf-cellar-matroska-15.html#name-track-flags
+[migrate-from-newtonsoft-link]: https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/migrate-from-newtonsoft
+[mkvtoolnix-languages-link]: https://codeberg.org/mbunkus/mkvtoolnix/wiki/Languages-in-Matroska-and-MKVToolNix
+[native-aot-cross-compile-link]: https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/cross-compile
+[native-aot-link]: https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot
+[nerdbank-gitversioning-link]: https://github.com/dotnet/Nerdbank.GitVersioning
+[nullable-value-types-link]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/nullable-value-types
+[omnisharp-remote-link]: https://github.com/OmniSharp/omnisharp-vscode/wiki/Attaching-to-remote-processes
+[remote-debugging-link]: https://learn.microsoft.com/en-us/visualstudio/debugger/remote-debugging-dotnet-core-linux-with-ssh
 [savoury-link]: https://launchpad.net/~savoury1
+[sevenzip-releases-link]: https://github.com/ip7z/7zip/releases
+[stackoverflow-xmlserializer-link]: https://stackoverflow.com/questions/79858800/statically-generated-xml-parsing-code-using-microsoft-xmlserializer-generator
+[ubuntu-releases-link]: https://releases.ubuntu.com/
 [utf8jsonasync-link]: https://github.com/gragra33/Utf8JsonAsyncStreamReader
+[vs-docker-debug-link]: https://docs.microsoft.com/en-us/visualstudio/debugger/attach-to-process-running-in-docker-container?view=vs-2022
+[vsdbg-link]: https://aka.ms/getvsdbgsh

--- a/PlexCleaner/FfMpegBuilder.cs
+++ b/PlexCleaner/FfMpegBuilder.cs
@@ -29,6 +29,8 @@ public partial class FfMpeg
 
         public GlobalOptions NoStats() => Add("-nostats");
 
+        public GlobalOptions Progress() => Add("-progress").Add("pipe:1");
+
         public GlobalOptions ExitOnError() => Add("-xerror");
 
         public GlobalOptions AbortOn() => Add("-abort_on");

--- a/PlexCleaner/FfMpegTool.cs
+++ b/PlexCleaner/FfMpegTool.cs
@@ -289,6 +289,45 @@ public partial class FfMpeg
             outputMap = outputMap.Trim();
         }
 
+        // Parse an ffmpeg -progress line to a fraction, or null. out_time_us and out_time_ms are microseconds.
+        internal static double? ParseProgressFraction(string line, long durationUs)
+        {
+            int separator = line.IndexOf('=');
+            if (separator <= 0)
+            {
+                return null;
+            }
+            string value = line[(separator + 1)..];
+            return line[..separator] switch
+            {
+                "progress" when value == "end" => 1.0,
+                "out_time_us"
+                or "out_time_ms"
+                    when durationUs > 0
+                        && long.TryParse(value, CultureInfo.InvariantCulture, out long microseconds)
+                        && microseconds > 0 => (double)microseconds / durationUs,
+                _ => null,
+            };
+        }
+
+        private bool ExecuteEncodeWithProgress(Command command, string inputName)
+        {
+            Metrics.FileSink? sink = Metrics.CurrentFileSink;
+            return ExecuteStreamStdOut(
+                    command,
+                    line =>
+                    {
+                        double? fraction = ParseProgressFraction(line, sink?.DurationUs ?? 0);
+                        if (fraction.HasValue)
+                        {
+                            Metrics.ReportFileFraction(sink, fraction.Value);
+                        }
+                    },
+                    out int exitCode,
+                    out string standardError
+                ) && (exitCode == 0 || LogFailedResult(exitCode, standardError, inputName));
+        }
+
         public bool ConvertToMkv(
             string inputName,
             SelectMediaProps? selectMediaProps,
@@ -312,7 +351,10 @@ public partial class FfMpeg
             // Build command line
             Command command = GetBuilder()
                 .GlobalOptions(options =>
-                    options.Default().Add(Program.Config.ConvertOptions.FfMpegOptions.Global)
+                    options
+                        .Default()
+                        .Progress()
+                        .Add(Program.Config.ConvertOptions.FfMpegOptions.Global)
                 )
                 .InputOptions(options => options.Default().TestSnippets().InputFile(inputName))
                 .OutputOptions(options =>
@@ -326,8 +368,7 @@ public partial class FfMpeg
                 .Build();
 
             // Execute command
-            return Execute(command, true, true, out BufferedCommandResult result)
-                && (result.ExitCode == 0 || LogFailedResult(result, inputName));
+            return ExecuteEncodeWithProgress(command, inputName);
         }
 
         public bool ConvertToMkv(string inputName, string outputName)
@@ -338,7 +379,10 @@ public partial class FfMpeg
             // Build command line
             Command command = GetBuilder()
                 .GlobalOptions(options =>
-                    options.Default().Add(Program.Config.ConvertOptions.FfMpegOptions.Global)
+                    options
+                        .Default()
+                        .Progress()
+                        .Add(Program.Config.ConvertOptions.FfMpegOptions.Global)
                 )
                 .InputOptions(options => options.Default().TestSnippets().InputFile(inputName))
                 .OutputOptions(options =>
@@ -354,8 +398,7 @@ public partial class FfMpeg
                 .Build();
 
             // Execute command
-            return Execute(command, true, true, out BufferedCommandResult result)
-                && (result.ExitCode == 0 || LogFailedResult(result, inputName));
+            return ExecuteEncodeWithProgress(command, inputName);
         }
 
         public bool SetTimestamps(string inputName, string outputName)

--- a/PlexCleaner/HandBrakeBuilder.cs
+++ b/PlexCleaner/HandBrakeBuilder.cs
@@ -10,6 +10,8 @@ public partial class HandBrake
         // TODO: Consolidate
         public GlobalOptions Default() => this;
 
+        public GlobalOptions Json() => Add("--json");
+
         public GlobalOptions Add(string option) => Add(option, false);
 
         public GlobalOptions Add(string option, bool escape)

--- a/PlexCleaner/HandBrakeTool.cs
+++ b/PlexCleaner/HandBrakeTool.cs
@@ -91,6 +91,24 @@ public partial class HandBrake
             return true;
         }
 
+        // Parse a HandBrake --json line to a fraction, or null. Progress is 0..1 across scan, work, and mux.
+        internal static double? ParseProgressFraction(string line)
+        {
+            Match match = ProgressRegex().Match(line);
+            return
+                match.Success
+                && double.TryParse(
+                    match.Groups[1].Value,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out double progress
+                )
+                ? progress
+                : null;
+        }
+
+        [GeneratedRegex("\"Progress\":\\s*([0-9.]+)")]
+        private static partial Regex ProgressRegex();
+
         public bool ConvertToMkv(
             string inputName,
             string outputName,
@@ -103,7 +121,7 @@ public partial class HandBrake
 
             // Build command line
             Command command = GetBuilder()
-                .GlobalOptions(options => options.Default())
+                .GlobalOptions(options => options.Default().Json())
                 .InputOptions(options => options.InputFile(inputName).TestSnippets())
                 .OutputOptions(options =>
                     options
@@ -122,8 +140,20 @@ public partial class HandBrake
                 .Build();
 
             // Execute command
-            return Execute(command, true, true, out BufferedCommandResult result)
-                && (result.ExitCode == 0 || LogFailedResult(result, inputName));
+            Metrics.FileSink? sink = Metrics.CurrentFileSink;
+            return ExecuteStreamStdOut(
+                    command,
+                    line =>
+                    {
+                        double? fraction = ParseProgressFraction(line);
+                        if (fraction.HasValue)
+                        {
+                            Metrics.ReportFileFraction(sink, fraction.Value);
+                        }
+                    },
+                    out int exitCode,
+                    out string standardError
+                ) && (exitCode == 0 || LogFailedResult(exitCode, standardError, inputName));
         }
 
         [GeneratedRegex(

--- a/PlexCleaner/MediaTool.cs
+++ b/PlexCleaner/MediaTool.cs
@@ -148,6 +148,39 @@ public abstract class MediaTool
         return false;
     }
 
+    // Overload for the streaming exec paths, which return the captured stderr directly.
+    protected bool LogFailedResult(
+        int exitCode,
+        string errorOutput,
+        string fileName,
+        [CallerMemberName] string operation = ""
+    )
+    {
+        string summary = CleanForLog(Summarize(errorOutput.Trim()));
+        if (string.IsNullOrEmpty(summary))
+        {
+            Log.Error(
+                "Failed execution of {ToolType} : {Operation:l} : ExitCode: {ExitCode} : {FileName}",
+                GetToolType(),
+                operation,
+                exitCode,
+                fileName
+            );
+        }
+        else
+        {
+            Log.Error(
+                "Failed execution of {ToolType} : {Operation:l} : ExitCode: {ExitCode} : {Error} : {FileName}",
+                GetToolType(),
+                operation,
+                exitCode,
+                summary,
+                fileName
+            );
+        }
+        return false;
+    }
+
     // Join lines with " | " and drop other control characters so multi-line tool output stays a single structured log value; printable Unicode (e.g. media titles) is preserved
     protected static string CleanForLog(string text)
     {
@@ -278,6 +311,81 @@ public abstract class MediaTool
 
             CommandResult commandResult = task.Task.GetAwaiter().GetResult();
             exitCode = commandResult.ExitCode;
+            return task.Task.IsCompletedSuccessfully;
+        }
+        catch (OperationCanceledException)
+        {
+            Log.Error(
+                "Cancelled execution of {ToolType} : {Operation:l} : ProcessId: {ProcessId}, Arguments: {Arguments}",
+                GetToolType(),
+                operation,
+                processId,
+                command.Arguments
+            );
+            return false;
+        }
+        catch (Exception e) when (Log.Logger.LogAndHandle(e))
+        {
+            return false;
+        }
+        finally
+        {
+            Metrics.RecordToolDuration(
+                GetToolType(),
+                Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds
+            );
+        }
+    }
+
+    public bool ExecuteStreamStdOut(
+        Command command,
+        Action<string> lineAction,
+        out int exitCode,
+        out string standardError,
+        [CallerMemberName] string operation = ""
+    )
+    {
+        exitCode = -1;
+        standardError = string.Empty;
+        int processId = -1;
+        long startTimestamp = Stopwatch.GetTimestamp();
+        try
+        {
+            // Stream stdout line by line to the caller (progress output), summarize stderr for logging
+            PipeTarget stdOutTarget = PipeTarget.Create(
+                async (stream, cancellationToken) =>
+                {
+                    using StreamReader reader = new(stream, Encoding.Default, false, 1024, true);
+                    while (await reader.ReadLineAsync(cancellationToken) is { } line)
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            return;
+                        }
+                        lineAction(line);
+                    }
+                }
+            );
+            StringBuilder stdErrBuilder = new();
+            PipeTarget stdErrTarget = ToStringSummary(stdErrBuilder);
+
+            CommandTask<CommandResult> task = command
+                .WithStandardOutputPipe(stdOutTarget)
+                .WithStandardErrorPipe(stdErrTarget)
+                .WithValidation(CommandResultValidation.None)
+                .ExecuteAsync(CancellationToken.None, Program.CancelToken());
+            processId = task.ProcessId;
+            Log.Debug(
+                "Executing {ToolType} : {Operation:l} : ProcessId: {ProcessId}, Arguments: {Arguments}",
+                GetToolType(),
+                operation,
+                processId,
+                command.Arguments
+            );
+
+            CommandResult commandResult = task.Task.GetAwaiter().GetResult();
+            exitCode = commandResult.ExitCode;
+            standardError = stdErrBuilder.ToString();
             return task.Task.IsCompletedSuccessfully;
         }
         catch (OperationCanceledException)

--- a/PlexCleaner/Metrics.cs
+++ b/PlexCleaner/Metrics.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 
@@ -5,6 +6,21 @@ namespace PlexCleaner;
 
 internal static class Metrics
 {
+    // Per-file partial credit for the in-flight fold.
+    internal sealed class FileSink
+    {
+        internal long Bytes { get; init; }
+        internal long DurationUs { get; set; }
+
+        // Fraction as a 0..10000 permyriad so it reads and writes atomically as an int.
+        private int _permyriad;
+
+        internal double Fraction => Volatile.Read(ref _permyriad) / 10000.0;
+
+        internal void SetFraction(double fraction) =>
+            Volatile.Write(ref _permyriad, (int)Math.Clamp(fraction * 10000.0, 0.0, 10000.0));
+    }
+
     private static readonly Meter s_meter = new("PlexCleaner.Process");
 
     // Cumulative for the process lifetime, not reset between runs.
@@ -47,6 +63,10 @@ internal static class Metrics
     private static long s_runBytesCompleted;
     private static long s_runInflight;
     private static long s_runStartTimestamp;
+
+    // The current file is exposed via ThreadLocal so a worker-thread call site can capture it for a tool closure.
+    private static readonly ConcurrentDictionary<FileSink, byte> s_runInflightSinks = new();
+    private static readonly ThreadLocal<FileSink?> s_currentFileSink = new();
 
     // Each State flag (minus None) with its tag, pre-built once so RecordStates allocates nothing per file.
     private static readonly (
@@ -119,13 +139,44 @@ internal static class Metrics
         _ = Interlocked.Exchange(ref s_runBytesCompleted, 0);
         _ = Interlocked.Exchange(ref s_runInflight, 0);
         _ = Interlocked.Exchange(ref s_runStartTimestamp, Stopwatch.GetTimestamp());
+        s_runInflightSinks.Clear();
     }
 
-    internal static void FileStarted() => Interlocked.Increment(ref s_runInflight);
+    internal static void FileStarted(long sizeBytes)
+    {
+        FileSink sink = new() { Bytes = sizeBytes };
+        _ = s_runInflightSinks.TryAdd(sink, 0);
+        s_currentFileSink.Value = sink;
+        _ = Interlocked.Increment(ref s_runInflight);
+    }
 
-    internal static void FileInflightDone() => Interlocked.Decrement(ref s_runInflight);
+    // Remove the current file's partial credit before FileCompleted folds its whole size.
+    internal static void FileInflightDone()
+    {
+        FileSink? sink = s_currentFileSink.Value;
+        s_currentFileSink.Value = null;
+        if (sink != null)
+        {
+            _ = s_runInflightSinks.TryRemove(sink, out _);
+        }
+        _ = Interlocked.Decrement(ref s_runInflight);
+    }
 
-    // A finished file credits its whole size (no partial credit in v1) and its wall-clock time.
+    internal static FileSink? CurrentFileSink => s_currentFileSink.Value;
+
+    internal static void SetCurrentFileDurationUs(long durationUs)
+    {
+        if (s_currentFileSink.Value is { } sink)
+        {
+            sink.DurationUs = durationUs;
+        }
+    }
+
+    // Safe to call from a tool's pipe thread.
+    internal static void ReportFileFraction(FileSink? sink, double fraction) =>
+        sink?.SetFraction(fraction);
+
+    // A finished file credits its whole size and its wall-clock time.
     internal static void FileCompleted(long sizeBytes, TimeSpan wall)
     {
         _ = Interlocked.Add(ref s_runBytesCompleted, sizeBytes);
@@ -153,13 +204,26 @@ internal static class Metrics
     internal static void RecordToolDuration(MediaTool.ToolType tool, double milliseconds) =>
         s_toolDuration.Record(milliseconds, s_toolTags[tool]);
 
-    internal static void Dispose() => s_meter.Dispose();
+    internal static void Dispose()
+    {
+        s_currentFileSink.Dispose();
+        s_meter.Dispose();
+    }
 
-    // Byte-weighted progress, guards a zero (or not-yet-started) total.
+    // Completed bytes plus each in-flight file's partial credit, byte-weighted, guarding a zero total.
     internal static double ComputeProgress()
     {
         long total = Interlocked.Read(ref s_runBytesTotal);
-        return total <= 0 ? 0.0 : (double)Interlocked.Read(ref s_runBytesCompleted) / total;
+        if (total <= 0)
+        {
+            return 0.0;
+        }
+        double completed = Interlocked.Read(ref s_runBytesCompleted);
+        foreach (KeyValuePair<FileSink, byte> entry in s_runInflightSinks)
+        {
+            completed += entry.Key.Bytes * entry.Key.Fraction;
+        }
+        return Math.Clamp(completed / total, 0.0, 1.0);
     }
 
     // Linear extrapolation from weighted progress and elapsed time.

--- a/PlexCleaner/Metrics.cs
+++ b/PlexCleaner/Metrics.cs
@@ -10,7 +10,13 @@ internal static class Metrics
     internal sealed class FileSink
     {
         internal long Bytes { get; init; }
-        internal long DurationUs { get; set; }
+
+        // Written on the worker thread and read on the tool pipe thread, so accessed via Volatile.
+        private long _durationUs;
+
+        internal long DurationUs => Volatile.Read(ref _durationUs);
+
+        internal void SetDurationUs(long durationUs) => Volatile.Write(ref _durationUs, durationUs);
 
         // Fraction as a 0..10000 permyriad so it reads and writes atomically as an int.
         private int _permyriad;
@@ -168,7 +174,7 @@ internal static class Metrics
     {
         if (s_currentFileSink.Value is { } sink)
         {
-            sink.DurationUs = durationUs;
+            sink.SetDurationUs(durationUs);
         }
     }
 

--- a/PlexCleaner/Process.cs
+++ b/PlexCleaner/Process.cs
@@ -152,6 +152,11 @@ public static class Process
                 break;
             }
 
+            // Seed the ffmpeg progress denominator now that the duration is known
+            Metrics.SetCurrentFileDurationUs(
+                (long)processFile.FfProbeProps.Duration.TotalMicroseconds
+            );
+
             // ReMux non-MKV containers using MKV file extensions
             // Conditional on ReMux option, fails if not Matroska and ReMux is not enabled
             operation = nameof(processFile.RemuxNonMkvContainer);

--- a/PlexCleaner/ProcessDriver.cs
+++ b/PlexCleaner/ProcessDriver.cs
@@ -206,7 +206,7 @@ public static class ProcessDriver
                         // Perform the task, timing this file's work.
                         // Decrement the in-flight count in a finally so a cancellation cannot leak it.
                         long fileSize = fileSizes.GetValueOrDefault(fileName);
-                        Metrics.FileStarted();
+                        Metrics.FileStarted(fileSize);
                         long startTimestamp = Stopwatch.GetTimestamp();
                         bool taskResult;
                         try

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -2554,6 +2554,7 @@ public class ProcessFile
         // Capture the sink here so the pipe-thread packet lambda can report pts over duration.
         Metrics.FileSink? sink = Metrics.CurrentFileSink;
         double durationSeconds = FfProbeProps.Duration.TotalSeconds;
+        double maxPtsSeconds = 0;
 
         if (
             !Tools.FfProbe.GetAnalysisPackets(
@@ -2562,13 +2563,15 @@ public class ProcessFile
                 {
                     packetBitrate.Add(packet);
                     packetDts.Add(packet);
+                    // Track the max pts so reordered packet timestamps only move the fraction forward.
                     if (
                         durationSeconds > 0
                         && double.IsFinite(packet.PtsTime)
-                        && packet.PtsTime > 0
+                        && packet.PtsTime > maxPtsSeconds
                     )
                     {
-                        Metrics.ReportFileFraction(sink, packet.PtsTime / durationSeconds);
+                        maxPtsSeconds = packet.PtsTime;
+                        Metrics.ReportFileFraction(sink, maxPtsSeconds / durationSeconds);
                     }
                     return true;
                 },

--- a/PlexCleaner/ProcessFile.cs
+++ b/PlexCleaner/ProcessFile.cs
@@ -2550,6 +2550,11 @@ public class ProcessFile
             Program.Config.VerifyOptions.MaximumBitrate / 8
         );
         DtsInfo packetDts = new();
+
+        // Capture the sink here so the pipe-thread packet lambda can report pts over duration.
+        Metrics.FileSink? sink = Metrics.CurrentFileSink;
+        double durationSeconds = FfProbeProps.Duration.TotalSeconds;
+
         if (
             !Tools.FfProbe.GetAnalysisPackets(
                 FileInfo.FullName,
@@ -2557,6 +2562,14 @@ public class ProcessFile
                 {
                     packetBitrate.Add(packet);
                     packetDts.Add(packet);
+                    if (
+                        durationSeconds > 0
+                        && double.IsFinite(packet.PtsTime)
+                        && packet.PtsTime > 0
+                    )
+                    {
+                        Metrics.ReportFileFraction(sink, packet.PtsTime / durationSeconds);
+                    }
                     return true;
                 },
                 quickScan

--- a/PlexCleanerTests/MetricsTests.cs
+++ b/PlexCleanerTests/MetricsTests.cs
@@ -104,14 +104,13 @@ public class MetricsTests
         );
         listener.Start();
 
-        // Two files start; one finishes 400 of 1000 bytes (leaves flight and is credited); record a
-        // two-flag outcome for it
+        // One file completes at 400 bytes and a second stays in flight, so byte-weighted progress is 0.4
         Metrics.BeginRun(2, 1000);
-        Metrics.FileStarted(500);
-        Metrics.FileStarted(500);
+        Metrics.FileStarted(400);
         Metrics.FileInflightDone();
         Metrics.FileCompleted(400, TimeSpan.Zero);
         Metrics.RecordStates(SidecarFile.StatesType.ReMuxed | SidecarFile.StatesType.Verified);
+        Metrics.FileStarted(600);
         listener.RecordObservableInstruments();
 
         // The counter fired one measurement per set flag with the state tag
@@ -134,6 +133,9 @@ public class MetricsTests
             .ContainSingle(m => m.Name == "plexcleaner.progress.ratio")
             .Which.Value.Should()
             .BeApproximately(0.4, 1e-9);
+
+        // Clear the in-flight file's thread-local sink
+        Metrics.FileInflightDone();
     }
 
     [Fact]

--- a/PlexCleanerTests/MetricsTests.cs
+++ b/PlexCleanerTests/MetricsTests.cs
@@ -107,8 +107,8 @@ public class MetricsTests
         // Two files start; one finishes 400 of 1000 bytes (leaves flight and is credited); record a
         // two-flag outcome for it
         Metrics.BeginRun(2, 1000);
-        Metrics.FileStarted();
-        Metrics.FileStarted();
+        Metrics.FileStarted(500);
+        Metrics.FileStarted(500);
         Metrics.FileInflightDone();
         Metrics.FileCompleted(400, TimeSpan.Zero);
         Metrics.RecordStates(SidecarFile.StatesType.ReMuxed | SidecarFile.StatesType.Verified);
@@ -134,5 +134,53 @@ public class MetricsTests
             .ContainSingle(m => m.Name == "plexcleaner.progress.ratio")
             .Which.Value.Should()
             .BeApproximately(0.4, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeProgress_FoldsInflightPartialCredit()
+    {
+        Metrics.BeginRun(2, 1000);
+        Metrics.FileStarted(600);
+        Metrics.FileSink? sink = Metrics.CurrentFileSink;
+
+        // 600 bytes at half done is 30% of the 1000-byte run
+        Metrics.ReportFileFraction(sink, 0.5);
+        _ = Metrics.ComputeProgress().Should().BeApproximately(0.3, 1e-9);
+
+        Metrics.ReportFileFraction(sink, 1.0);
+        _ = Metrics.ComputeProgress().Should().BeApproximately(0.6, 1e-9);
+
+        // Finishing removes the partial credit and credits the whole size, same result here
+        Metrics.FileInflightDone();
+        Metrics.FileCompleted(600, TimeSpan.Zero);
+        _ = Metrics.ComputeProgress().Should().BeApproximately(0.6, 1e-9);
+    }
+
+    [Fact]
+    public void ReportFileFraction_ClampsOutOfRange()
+    {
+        Metrics.BeginRun(1, 1000);
+        Metrics.FileStarted(1000);
+        Metrics.FileSink? sink = Metrics.CurrentFileSink;
+
+        Metrics.ReportFileFraction(sink, 1.5);
+        _ = Metrics.ComputeProgress().Should().Be(1.0);
+
+        Metrics.ReportFileFraction(sink, -0.5);
+        _ = Metrics.ComputeProgress().Should().Be(0.0);
+
+        Metrics.FileInflightDone();
+    }
+
+    [Fact]
+    public void FileInflightDone_RemovesPartialCredit()
+    {
+        Metrics.BeginRun(1, 1000);
+        Metrics.FileStarted(400);
+        Metrics.ReportFileFraction(Metrics.CurrentFileSink, 1.0);
+        _ = Metrics.ComputeProgress().Should().BeApproximately(0.4, 1e-9);
+
+        Metrics.FileInflightDone();
+        _ = Metrics.ComputeProgress().Should().Be(0.0);
     }
 }

--- a/PlexCleanerTests/ToolProgressParsingTests.cs
+++ b/PlexCleanerTests/ToolProgressParsingTests.cs
@@ -1,0 +1,46 @@
+using AwesomeAssertions;
+using PlexCleaner;
+using Xunit;
+
+namespace PlexCleanerTests;
+
+public class ToolProgressParsingTests
+{
+    [Theory]
+    [InlineData("out_time_us=5000000", 10000000L, 0.5)]
+    [InlineData("out_time_ms=2500000", 10000000L, 0.25)]
+    [InlineData("progress=end", 10000000L, 1.0)]
+    public void FfMpegProgress_ParsesFraction(string line, long durationUs, double expected)
+    {
+        double? fraction = FfMpeg.Tool.ParseProgressFraction(line, durationUs);
+
+        _ = fraction.Should().NotBeNull();
+        _ = fraction.Value.Should().BeApproximately(expected, 1e-9);
+    }
+
+    [Theory]
+    [InlineData("frame=100", 10000000L)] // not a position line
+    [InlineData("out_time_us=0", 10000000L)] // zero position
+    [InlineData("out_time_us=5000000", 0L)] // no duration
+    [InlineData("progress=continue", 10000000L)] // continue is not a terminal
+    [InlineData("garbage", 10000000L)]
+    public void FfMpegProgress_ReturnsNullWithoutPosition(string line, long durationUs) =>
+        _ = FfMpeg.Tool.ParseProgressFraction(line, durationUs).Should().BeNull();
+
+    [Theory]
+    [InlineData("  \"Progress\": 0.42,", 0.42)]
+    [InlineData("\"Progress\":1.0", 1.0)]
+    public void HandBrakeProgress_ParsesFraction(string line, double expected)
+    {
+        double? fraction = HandBrake.Tool.ParseProgressFraction(line);
+
+        _ = fraction.Should().NotBeNull();
+        _ = fraction.Value.Should().BeApproximately(expected, 1e-9);
+    }
+
+    [Theory]
+    [InlineData("\"State\": \"WORKING\"")]
+    [InlineData("random line")]
+    public void HandBrakeProgress_ReturnsNullWithoutProgress(string line) =>
+        _ = HandBrake.Tool.ParseProgressFraction(line).Should().BeNull();
+}

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ See [Installation](#installation) for detailed setup instructions and other plat
 
 ## Use Cases
 
-> **ℹ️ TL;DR**: *Direct Play* means your media server (Plex/Emby/Jellyfin) sends the file directly to your player without transcoding on the server or the client. This saves server CPU, reduces power consumption, preserves quality, and enables playback on low-power devices. The **objective of PlexCleaner** is to *modify media content* such that it will always Direct Play in [Plex](https://support.plex.tv/articles/200250387-streaming-media-direct-play-and-direct-stream/), [Emby](https://support.emby.media/support/solutions/articles/44001920144-direct-play-vs-direct-streaming-vs-transcoding), [Jellyfin](https://jellyfin.org/docs/plugin-api/MediaBrowser.Model.Session.PlayMethod.html), etc.
+> **ℹ️ TL;DR**: *Direct Play* means your media server (Plex/Emby/Jellyfin) sends the file directly to your player without transcoding on the server or the client. This saves server CPU, reduces power consumption, preserves quality, and enables playback on low-power devices. The **objective of PlexCleaner** is to *modify media content* such that it will always Direct Play in [Plex][plex-directplay-link], [Emby][emby-directplay-link], [Jellyfin][jellyfin-playmethod-link], etc.
 
 Common examples of issues resolved by the `process` command:
 
@@ -161,7 +161,7 @@ PlexCleaner is optimized for processing large media libraries efficiently. Key p
 > - **Large libraries**: Use `--parallel` to process multiple files concurrently.
 > - **Testing**: Combine `--testsnippets` and `--quickscan` for faster test iterations.
 > - **Network storage**: Process files locally when possible to avoid network bottlenecks.
-> - **Docker logging**: Configure [log rotation](https://docs.docker.com/config/containers/logging/configure/) to prevent large log files.
+> - **Docker logging**: Configure [log rotation][docker-logging-link] to prevent large log files.
 > - **Thread count**: Default is half of CPU cores (max 4); adjust with `--threadcount` if needed.
 
 **Sidecar Files:**
@@ -178,7 +178,7 @@ PlexCleaner is optimized for processing large media libraries efficiently. Key p
 
 **Docker Considerations:**
 
-- Processing very large media collections on docker may result in a very large docker log file, set appropriate [docker logging](https://docs.docker.com/config/containers/logging/configure/) options.
+- Processing very large media collections on docker may result in a very large docker log file, set appropriate [docker logging][docker-logging-link] options.
 
 ## Installation
 
@@ -300,13 +300,13 @@ For one-time processing, see the [Getting Started](#getting-started) example or 
 
 **Prerequisites:**
 
-- For pre-compiled binaries: Install [.NET Runtime](https://docs.microsoft.com/en-us/dotnet/core/install/windows) (smaller, runtime only).
-- For compiling from source: Install [.NET SDK](https://dotnet.microsoft.com/download) (includes build tools).
+- For pre-compiled binaries: Install [.NET Runtime][dotnet-install-windows-link] (smaller, runtime only).
+- For compiling from source: Install [.NET SDK][dotnet-download-link] (includes build tools).
 
 **Installation Steps:**
 
-1. Download [PlexCleaner](https://github.com/ptr727/PlexCleaner/releases/latest) and extract the pre-compiled binaries.
-   - Or compile from [code](https://github.com/ptr727/PlexCleaner.git) using [Visual Studio](https://visualstudio.microsoft.com/downloads/) or [VSCode](https://code.visualstudio.com/download) with the .NET SDK.
+1. Download [PlexCleaner][releases-latest-link] and extract the pre-compiled binaries.
+   - Or compile from [code][clone-link] using [Visual Studio][visualstudio-link] or [VSCode][vscode-link] with the .NET SDK.
 
 2. Create a default JSON settings file using the `defaultsettings` command:
    - `PlexCleaner defaultsettings --settingsfile PlexCleaner.json`
@@ -321,7 +321,7 @@ For one-time processing, see the [Getting Started](#getting-started) example or 
    - Keep the 3rd party tools updated by periodically running the `checkfornewtools` command, or update tools on every run by setting `ToolsOptions:AutoUpdate` to `true`.
 
    **Option B: System-wide installation via winget**
-   - Run from an elevated shell e.g. using [`gsudo`](https://github.com/gerardog/gsudo), else [symlinks will not be created](https://github.com/microsoft/winget-cli/issues/3437).
+   - Run from an elevated shell e.g. using [`gsudo`][gsudo-link], else [symlinks will not be created][winget-cli-issue-link].
    - `winget install --id=Gyan.FFmpeg --exact`
    - `winget install --id=MediaArea.MediaInfo --exact`
    - `winget install --id=HandBrake.HandBrake.CLI --exact`
@@ -329,31 +329,31 @@ For one-time processing, see the [Getting Started](#getting-started) example or 
    - Set `ToolsOptions:UseSystem` to `true` and `ToolsOptions:AutoUpdate` to `false`.
 
    **Option C: Manual download**
-   - [FfMpeg Full](https://github.com/GyanD/codexffmpeg/releases), e.g. `ffmpeg-6.0-full.7z`: `\Tools\FfMpeg`
-   - [HandBrake CLI x64](https://github.com/HandBrake/HandBrake/releases), e.g. `HandBrakeCLI-1.6.1-win-x86_64.zip`: `\Tools\HandBrake`
-   - [MediaInfo CLI x64](https://mediaarea.net/en/MediaInfo/Download/Windows), e.g. `MediaInfo_CLI_23.07_Windows_x64.zip`: `\Tools\MediaInfo`
-   - [MkvToolNix Portable x64](https://mkvtoolnix.download/downloads.html#windows), e.g. `mkvtoolnix-64-bit-79.0.7z`: `\Tools\MkvToolNix`
-   - [7-Zip Extra](https://www.7-zip.org/download.html), e.g. `7z2301-extra.7z`: `\Tools\SevenZip`
+   - [FfMpeg Full][codexffmpeg-releases-link], e.g. `ffmpeg-6.0-full.7z`: `\Tools\FfMpeg`
+   - [HandBrake CLI x64][handbrake-releases-link], e.g. `HandBrakeCLI-1.6.1-win-x86_64.zip`: `\Tools\HandBrake`
+   - [MediaInfo CLI x64][mediainfo-download-link], e.g. `MediaInfo_CLI_23.07_Windows_x64.zip`: `\Tools\MediaInfo`
+   - [MkvToolNix Portable x64][mkvtoolnix-download-link], e.g. `mkvtoolnix-64-bit-79.0.7z`: `\Tools\MkvToolNix`
+   - [7-Zip Extra][sevenzip-download-link], e.g. `7z2301-extra.7z`: `\Tools\SevenZip`
    - Set `ToolsOptions:UseSystem` to `false` and `ToolsOptions:AutoUpdate` to `false`.
 
 ### Linux
 
 - Automatic downloading of Linux 3rd party tools are not supported, consider using the [Docker](#docker) build instead.
 - Manually install the 3rd party tools, e.g. following steps similar to the [Docker](./Docker) file commands.
-- Download [PlexCleaner](https://github.com/ptr727/PlexCleaner/releases/latest) and extract the pre-compiled binaries matching your platform.
-- Or compile from [code](https://github.com/ptr727/PlexCleaner.git) using the [.NET SDK](https://docs.microsoft.com/en-us/dotnet/core/install/linux).
+- Download [PlexCleaner][releases-latest-link] and extract the pre-compiled binaries matching your platform.
+- Or compile from [code][clone-link] using the [.NET SDK][dotnet-install-linux-link].
 - Create a default JSON settings file using the `defaultsettings` command:
   - `./PlexCleaner defaultsettings --settingsfile PlexCleaner.json`
   - Modify the settings to suit your needs.
 
 ### macOS
 
-- macOS x64 and Arm64 binaries are built as part of [Releases](https://github.com/ptr727/PlexCleaner/releases/latest), but are not tested during CI.
+- macOS x64 and Arm64 binaries are built as part of [Releases][releases-latest-link], but are not tested during CI.
 
 ### AOT
 
 Ahead-of-time compiled self-contained binaries do not require any .NET runtime components to be installed.\
-AOT builds are [platform specific](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot), require a platform native compiler, and are created using [`dotnet publish`](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish).
+AOT builds are [platform specific][native-aot-link], require a platform native compiler, and are created using [`dotnet publish`][dotnet-publish-link].
 
 > **ℹ️ Note**: AOT binaries are not published in CI/CD due to being platform specific, and cross compilation of AOT binaries are not supported.
 
@@ -492,7 +492,7 @@ Quick configuration examples for common use cases. Edit your `PlexCleaner.json` 
 
 ### IETF Language Matching
 
-> **ℹ️ TL;DR**: Language tag matching supports [IETF / RFC 5646 / BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) tag formats as implemented by [MkvMerge](https://codeberg.org/mbunkus/mkvtoolnix/wiki/Languages-in-Matroska-and-MKVToolNix).
+> **ℹ️ TL;DR**: Language tag matching supports [IETF / RFC 5646 / BCP 47][ietf-language-tag-link] tag formats as implemented by [MkvMerge][mkvtoolnix-languages-link].
 
 **Common Use Cases:**
 
@@ -766,7 +766,7 @@ Options:
 The `monitor` command will watch the specified folders for file changes, and periodically run the `process` command on the changed folders:
 
 - All the referenced directories will be watched for changes, and any changes will be added to a queue to be periodically processed.
-- The [FileSystemWatcher](https://docs.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher) used to monitor for changes may not always work as expected when changes are made via virtual or network filesystem, e.g. NFS or SMB backed volumes may not detect changes made directly to the underlying ZFS filesystem, while running directly on ZFS will work fine.
+- The [FileSystemWatcher][filesystemwatcher-link] used to monitor for changes may not always work as expected when changes are made via virtual or network filesystem, e.g. NFS or SMB backed volumes may not detect changes made directly to the underlying ZFS filesystem, while running directly on ZFS will work fine.
 
 Options:
 
@@ -836,12 +836,14 @@ Additional commands for specific tasks, organized by category:
 
 ## Runtime Metrics
 
-PlexCleaner publishes always-on runtime metrics via `System.Diagnostics.Metrics` under the `PlexCleaner.Process` meter, so a long-running `process` or `monitor` pass can be watched live with no extra setup. Overall progress is weighted by input bytes, not file count, so a run mixing small and large files reflects the actual work completed.
+PlexCleaner publishes always-on runtime metrics via `System.Diagnostics.Metrics` under the `PlexCleaner.Process` meter, so a long-running `process` or `monitor` pass can be watched live with no extra setup. Overall progress is weighted by input bytes, not file count, so a run mixing small and large files reflects the actual work completed. Progress advances smoothly during a long operation because each in-flight file contributes partial credit from the running tool (the full-file scan, the re-encode, and the deinterlace).
 
-Read the meter with [`dotnet-counters`](https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-counters):
+Read the meter with [`dotnet-counters`][dotnet-counters-link]:
 
 - Local: `dotnet-counters monitor -p <pid> --counters PlexCleaner.Process`
 - Docker: `docker exec <container> counters` (a bundled wrapper that runs the same command against the in-container process)
+
+The meter is also OpenTelemetry and [`dotnet-monitor`][dotnet-monitor-link] compatible if you want an HTTP or Prometheus surface.
 
 ## Custom Plugins
 
@@ -933,7 +935,7 @@ The [`Test.sh`](./Docker/Test.sh) script validates basic container functionality
 
 The [`Test.sh`](./Docker/Test.sh) test script is included in the docker build and can be used to test basic functionality from inside the container.
 
-If an external media path is not specified the test will download and use the [Matroska test files](https://github.com/ietf-wg-cellar/matroska-test-files/archive/refs/heads/master.zip).
+If an external media path is not specified the test will download and use the [Matroska test files][matroska-test-files-zip-link].
 
 ```shell
 docker run \
@@ -981,63 +983,121 @@ Some ideas being considered:
 
 ## 3rd Party Tools
 
-- [7-Zip](https://www.7-zip.org/)
-- [AwesomeAssertions](https://awesomeassertions.org/)
+- [7-Zip][sevenzip-link]
+- [AwesomeAssertions][awesomeassertions-link]
 - [CliWrap][cliwrap-link]
-- [Docker Hub Description](https://github.com/marketplace/actions/docker-hub-description)
-- [Docker Run Action](https://github.com/marketplace/actions/docker-run-action)
-- [dotnet-outdated](https://github.com/dotnet-outdated/dotnet-outdated)
-- [FFmpeg](https://www.ffmpeg.org/)
-- [Git Auto Commit](https://github.com/marketplace/actions/git-auto-commit)
-- [GitHub Actions](https://github.com/actions)
-- [GitHub Dependabot](https://github.com/dependabot)
-- [HandBrake](https://handbrake.fr/)
-- [Husky.Net](https://alirezanet.github.io/Husky.Net/)
-- [ISO 639-2 language tags](https://www.loc.gov/standards/iso639-2/langhome.html)
-- [ISO 639-3 language tags](https://iso639-3.sil.org/)
+- [Docker Hub Description][docker-hub-description-action-link]
+- [Docker Run Action][docker-run-action-link]
+- [dotnet-outdated][dotnet-outdated-link]
+- [FFmpeg][ffmpeg-link]
+- [Git Auto Commit][git-auto-commit-action-link]
+- [GitHub Actions][github-actions-link]
+- [GitHub Dependabot][dependabot-link]
+- [HandBrake][handbrake-link]
+- [Husky.Net][husky-link]
+- [ISO 639-2 language tags][iso639-2-link]
+- [ISO 639-3 language tags][iso639-3-link]
 - [JSON2CSharp][json2csharp-link]
-- [MediaInfo](https://mediaarea.net/en-us/MediaInfo/)
-- [MKVToolNix](https://mkvtoolnix.download/)
-- [NEbml](https://github.com/OlegZee/NEbml)
-- [Nerdbank.GitVersioning](https://github.com/marketplace/actions/nerdbank-gitversioning)
-- [regex101.com](https://regex101.com/)
-- [RFC 5646 language tags](https://www.rfc-editor.org/rfc/rfc5646.html)
-- [Serilog](https://serilog.net/)
+- [MediaInfo][mediainfo-link]
+- [MKVToolNix][mkvtoolnix-link]
+- [NEbml][nebml-link]
+- [Nerdbank.GitVersioning][nerdbank-gitversioning-action-link]
+- [regex101.com][regex101-link]
+- [RFC 5646 language tags][rfc5646-link]
+- [Serilog][serilog-link]
 - [Utf8JsonAsyncStreamReader][utf8jsonasync-link]
-- [Xml2CSharp](http://xmltocsharp.azurewebsites.net/)
-- [xUnit.Net](https://xunit.net/)
+- [Xml2CSharp][xmltocsharp-link]
+- [xUnit.Net][xunit-link]
 
 ## Sample Media Files
 
-- [DemoWorld](https://www.demo-world.eu/2d-demo-trailers-hd/)
-- [JellyFish](http://jell.yfish.us/)
-- [Kodi](https://kodi.wiki/view/Samples)
-- [Matroska](https://github.com/ietf-wg-cellar/matroska-test-files)
-- [MPlayer](https://samples.mplayerhq.hu/)
+- [DemoWorld][demo-world-link]
+- [JellyFish][jellyfish-link]
+- [Kodi][kodi-samples-link]
+- [Matroska][matroska-test-files-link]
+- [MPlayer][mplayer-samples-link]
 
 ## License
 
 Licensed under the [MIT License][license-link]\
 ![GitHub License][license-shield]
 
-[actions-link]: https://github.com/ptr727/PlexCleaner/actions
-[cliwrap-link]: https://github.com/Tyrrrz/CliWrap
-[commit-link]: https://github.com/ptr727/PlexCleaner/commits/main
-[discussions-link]: https://github.com/ptr727/PlexCleaner/discussions
+<!-- Shields -->
 [docker-develop-version-shield]: https://img.shields.io/docker/v/ptr727/plexcleaner/develop?label=Docker%20Develop&logo=docker&color=orange
 [docker-latest-version-shield]: https://img.shields.io/docker/v/ptr727/plexcleaner/latest?label=Docker%20Latest&logo=docker
-[docker-link]: https://hub.docker.com/r/ptr727/plexcleaner
 [docker-status-shield]: https://img.shields.io/github/actions/workflow/status/ptr727/PlexCleaner/publish-release.yml?event=schedule&logo=github&label=Docker%20Build
-[github-link]: https://github.com/ptr727/PlexCleaner
-[plexcleaner-hub-link]: https://hub.docker.com/r/ptr727/plexcleaner
-[issues-link]: https://github.com/ptr727/PlexCleaner/issues
-[json2csharp-link]: https://json2csharp.com
 [last-commit-shield]: https://img.shields.io/github/last-commit/ptr727/PlexCleaner?logo=github&label=Last%20Commit
-[license-link]: ./LICENSE
 [license-shield]: https://img.shields.io/github/license/ptr727/PlexCleaner?label=License
 [pre-release-version-shield]: https://img.shields.io/github/v/release/ptr727/PlexCleaner?include_prereleases&label=GitHub%20Pre-Release&logo=github
 [release-status-shield]: https://img.shields.io/github/actions/workflow/status/ptr727/PlexCleaner/publish-release.yml?event=schedule&logo=github&label=Releases%20Build
 [release-version-shield]: https://img.shields.io/github/v/release/ptr727/PlexCleaner?logo=github&label=GitHub%20Release
+
+<!-- Internal -->
+[actions-link]: https://github.com/ptr727/PlexCleaner/actions
+[clone-link]: https://github.com/ptr727/PlexCleaner.git
+[commit-link]: https://github.com/ptr727/PlexCleaner/commits/main
+[discussions-link]: https://github.com/ptr727/PlexCleaner/discussions
+[docker-link]: https://hub.docker.com/r/ptr727/plexcleaner
+[github-link]: https://github.com/ptr727/PlexCleaner
+[issues-link]: https://github.com/ptr727/PlexCleaner/issues
+[license-link]: ./LICENSE
+[plexcleaner-hub-link]: https://hub.docker.com/r/ptr727/plexcleaner
+[releases-latest-link]: https://github.com/ptr727/PlexCleaner/releases/latest
 [releases-link]: https://github.com/ptr727/PlexCleaner/releases
+
+<!-- External -->
+[awesomeassertions-link]: https://awesomeassertions.org/
+[cliwrap-link]: https://github.com/Tyrrrz/CliWrap
+[codexffmpeg-releases-link]: https://github.com/GyanD/codexffmpeg/releases
+[demo-world-link]: https://www.demo-world.eu/2d-demo-trailers-hd/
+[dependabot-link]: https://github.com/dependabot
+[docker-hub-description-action-link]: https://github.com/marketplace/actions/docker-hub-description
+[docker-logging-link]: https://docs.docker.com/config/containers/logging/configure/
+[docker-run-action-link]: https://github.com/marketplace/actions/docker-run-action
+[dotnet-counters-link]: https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-counters
+[dotnet-download-link]: https://dotnet.microsoft.com/download
+[dotnet-install-linux-link]: https://docs.microsoft.com/en-us/dotnet/core/install/linux
+[dotnet-install-windows-link]: https://docs.microsoft.com/en-us/dotnet/core/install/windows
+[dotnet-monitor-link]: https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-monitor
+[dotnet-outdated-link]: https://github.com/dotnet-outdated/dotnet-outdated
+[dotnet-publish-link]: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish
+[emby-directplay-link]: https://support.emby.media/support/solutions/articles/44001920144-direct-play-vs-direct-streaming-vs-transcoding
+[ffmpeg-link]: https://www.ffmpeg.org/
+[filesystemwatcher-link]: https://docs.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher
+[git-auto-commit-action-link]: https://github.com/marketplace/actions/git-auto-commit
+[github-actions-link]: https://github.com/actions
+[gsudo-link]: https://github.com/gerardog/gsudo
+[handbrake-link]: https://handbrake.fr/
+[handbrake-releases-link]: https://github.com/HandBrake/HandBrake/releases
+[husky-link]: https://alirezanet.github.io/Husky.Net/
+[ietf-language-tag-link]: https://en.wikipedia.org/wiki/IETF_language_tag
+[iso639-2-link]: https://www.loc.gov/standards/iso639-2/langhome.html
+[iso639-3-link]: https://iso639-3.sil.org/
+[jellyfin-playmethod-link]: https://jellyfin.org/docs/plugin-api/MediaBrowser.Model.Session.PlayMethod.html
+[jellyfish-link]: http://jell.yfish.us/
+[json2csharp-link]: https://json2csharp.com
+[kodi-samples-link]: https://kodi.wiki/view/Samples
+[matroska-test-files-link]: https://github.com/ietf-wg-cellar/matroska-test-files
+[matroska-test-files-zip-link]: https://github.com/ietf-wg-cellar/matroska-test-files/archive/refs/heads/master.zip
+[mediainfo-download-link]: https://mediaarea.net/en/MediaInfo/Download/Windows
+[mediainfo-link]: https://mediaarea.net/en-us/MediaInfo/
+[mkvtoolnix-download-link]: https://mkvtoolnix.download/downloads.html#windows
+[mkvtoolnix-languages-link]: https://codeberg.org/mbunkus/mkvtoolnix/wiki/Languages-in-Matroska-and-MKVToolNix
+[mkvtoolnix-link]: https://mkvtoolnix.download/
+[mplayer-samples-link]: https://samples.mplayerhq.hu/
+[native-aot-link]: https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot
+[nebml-link]: https://github.com/OlegZee/NEbml
+[nerdbank-gitversioning-action-link]: https://github.com/marketplace/actions/nerdbank-gitversioning
+[plex-directplay-link]: https://support.plex.tv/articles/200250387-streaming-media-direct-play-and-direct-stream/
+[regex101-link]: https://regex101.com/
+[rfc5646-link]: https://www.rfc-editor.org/rfc/rfc5646.html
+[serilog-link]: https://serilog.net/
+[sevenzip-download-link]: https://www.7-zip.org/download.html
+[sevenzip-link]: https://www.7-zip.org/
 [ubuntu-hub-link]: https://hub.docker.com/_/ubuntu
 [utf8jsonasync-link]: https://github.com/gragra33/Utf8JsonAsyncStreamReader
+[visualstudio-link]: https://visualstudio.microsoft.com/downloads/
+[vscode-link]: https://code.visualstudio.com/download
+[winget-cli-issue-link]: https://github.com/microsoft/winget-cli/issues/3437
+[xmltocsharp-link]: http://xmltocsharp.azurewebsites.net/
+[xunit-link]: https://xunit.net/


### PR DESCRIPTION
## Summary

Runtime metrics v2 (issue #848 follow-on). v1 credited a file's whole byte weight only at completion, so `progress.ratio` staircased and `eta.seconds` jumped. v2 folds **partial credit** for in-flight files: each in-flight file carries a fraction in [0,1] driven by its currently-running long tool, and `ComputeProgress` adds `Sum(inflight_bytes * fraction)` to the completed total. Metrics-only, no state file, no per-file detail exposed.

## Changes

- **Metrics**: per-file `FileSink` (byte weight + atomic permyriad fraction), a lock-free in-flight registry, and a `ThreadLocal` current-file sink captured at each tool call site so a CliWrap pipe-thread closure can report progress without touching the ThreadLocal. Completion still credits the whole size (no double counting); the sink is removed and the ThreadLocal cleared in the driver `finally`.
- **`MediaTool.ExecuteStreamStdOut`**: streams stdout line-by-line for progress while capturing stderr for failure logging.
- **Instrumented long ops only**: ffprobe full-file scan (pts/duration), ffmpeg re-encode (`-progress pipe:1`), HandBrake re-encode (`--json` `Working.Progress`). Fast remux/copy/setts stay at 0 until completion.
- **Docs**: README Runtime Metrics section notes partial-credit progress + dotnet-counters/dotnet-monitor recipes; HISTORY 3.22 entry. All README/HISTORY inline URIs converted to reference-style links, grouped shields/internal/external and alphabetized.

No version bump (stays 3.22). No new NuGet package (Metrics + ConcurrentDictionary + ThreadLocal are BCL).

## Verification

- Build analyzer-clean, 0 warnings under `TreatWarningsAsErrors`/`AnalysisMode=All`
- `dotnet format style --verify-no-changes --severity=info` clean, CSharpier clean
- 241/241 tests pass, incl. new fold-math and tool progress-parser tests
- markdownlint + cspell clean

## Follow-up (not in this PR)

Develop Docker build, then regression testing with `dotnet-counters monitor --counters PlexCleaner.Process` to confirm `progress.ratio` climbs smoothly and `eta.seconds` decays smoothly during real scans/re-encodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)