### PR TITLE
Re-vendor the release task with the validate-release entry gate

### DIFF
--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -1,7 +1,8 @@
 name: Build project release task
 
-# Orchestrate one branch's release: version once (get-version), build the executable 7z and the Docker image, then
-# create the GitHub release. github/dockerhub gate the two publish targets; smoke builds everything, publishes nothing.
+# Orchestrate one branch's release: version once (get-version), gate on branch<->version consistency
+# (validate-release), build the executable 7z and the Docker image, then create the GitHub release.
+# github/dockerhub gate the two publish targets; smoke builds everything, publishes nothing.
 on:
   workflow_call:
     inputs:
@@ -27,6 +28,12 @@ on:
         required: false
         type: boolean
         default: false
+      # Set false for a repo that produces no release-asset-* files (e.g. Docker-only): the release is then just the
+      # tag + source zip + README + LICENSE; the artifact download is skipped and the unmatched-files guard relaxes.
+      expect_release_assets:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
 
@@ -48,11 +55,43 @@ jobs:
     with:
       ref: ${{ inputs.ref }}
 
+  # Entry gate: validate branch<->version consistency once, before the build jobs, so an NBGV mis-classification fails
+  # fast instead of after building and publishing. main must be a public release (no prerelease '-'); every other branch
+  # must carry a prerelease '-' (guards a develop leg being classified public and published as stable). Strip
+  # '+buildmetadata' first; a '-' there is legitimate, only a '-' in the core/prerelease segment marks a prerelease.
+  validate-release:
+    name: Validate release version job
+    needs: [get-version]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch and version consistency step
+        env:
+          SEMVER2: ${{ needs.get-version.outputs.SemVer2 }}
+          BRANCH: ${{ inputs.branch }}
+          SMOKE: ${{ inputs.smoke }}
+        run: |
+          set -Eeuo pipefail
+          # Smoke builds never publish and always version as prerelease (detached PR HEAD), which would trip the main arm.
+          if [[ "$SMOKE" == "true" ]]; then
+            echo "Smoke build; skipping release version validation."
+            exit 0
+          fi
+          CORE_AND_PRE="${SEMVER2%%+*}"
+          if [[ "$BRANCH" == "main" ]]; then
+            if [[ "$CORE_AND_PRE" == *-* ]]; then
+              echo "::error::Public (main) release version '$SEMVER2' carries a prerelease suffix; refusing to publish."
+              exit 1
+            fi
+          elif [[ "$CORE_AND_PRE" != *-* ]]; then
+            echo "::error::Prerelease ($BRANCH) version '$SEMVER2' has no prerelease suffix (NBGV classified it public); refusing to publish."
+            exit 1
+          fi
+
   # Build only when validation passed (success) or was skipped (smoke); never when it failed.
   build-executable:
     name: Build executable job
-    needs: [get-version, validate]
-    if: ${{ !cancelled() && needs.get-version.result == 'success' && (needs.validate.result == 'success' || needs.validate.result == 'skipped') }}
+    needs: [get-version, validate, validate-release]
+    if: ${{ !cancelled() && needs.get-version.result == 'success' && needs.validate-release.result == 'success' && (needs.validate.result == 'success' || needs.validate.result == 'skipped') }}
     uses: ./.github/workflows/build-executable-task.yml
     secrets: inherit
     with:
@@ -65,10 +104,15 @@ jobs:
       assembly_file_version: ${{ needs.get-version.outputs.AssemblyFileVersion }}
       assembly_informational_version: ${{ needs.get-version.outputs.AssemblyInformationalVersion }}
 
+  # Docker is the terminal registry push, so it must never push on a partial run. It needs every other build and
+  # guards with `!failure() && !cancelled()`: a *failed* build skips docker (no build, no push), while a *skipped*
+  # build - validate on a smoke run - does not, so docker still builds on smoke. Plain `needs` cannot express this
+  # (a skipped need skips the dependent). The github-release job reaches the same intent more simply because it
+  # only runs on a publish (`!inputs.smoke`), where nothing is skipped.
   build-docker:
     name: Build Docker job
-    needs: [get-version, validate]
-    if: ${{ !cancelled() && needs.get-version.result == 'success' && (needs.validate.result == 'success' || needs.validate.result == 'skipped') }}
+    needs: [get-version, validate, validate-release, build-executable]
+    if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/build-docker-task.yml
     secrets: inherit
     with:
@@ -85,10 +129,11 @@ jobs:
 
   github-release:
     name: Publish GitHub release job
-    # !smoke enforces "smoke never publishes" even if a smoke caller set github: true.
+    # `!inputs.smoke` enforces "smoke never publishes" at the job level, so a smoke caller that also set
+    # `github: true` still can't create a release.
     if: ${{ inputs.github && !inputs.smoke }}
     runs-on: ubuntu-latest
-    needs: [get-version, build-executable, build-docker]
+    needs: [get-version, validate-release, build-executable, build-docker]
 
     steps:
 
@@ -98,36 +143,28 @@ jobs:
         with:
           ref: ${{ needs.get-version.outputs.GitCommitId }}
 
-      # Backstop (main only): refuse to publish if the public version carries a prerelease '-' (NBGV mis-versioning).
-      # Strip '+buildmetadata' first; only a '-' in the core segment marks a prerelease.
-      - name: Verify public release version step
-        if: ${{ inputs.branch == 'main' }}
-        env:
-          SEMVER2: ${{ needs.get-version.outputs.SemVer2 }}
-        run: |
-          set -euo pipefail
-          CORE_AND_PRE="${SEMVER2%%+*}"   # drop +buildmetadata; a '-' here is the genuine prerelease separator
-          if [[ "$CORE_AND_PRE" == *-* ]]; then
-            echo "::error::Public (main) release version '$SEMVER2' carries a prerelease suffix; refusing to publish."
-            exit 1
-          fi
-
-      # Collect the executable build's release-asset-<branch>-* artifacts (the PlexCleaner.7z) by pattern.
+      # Collect assets by the `release-asset-<branch>-*` pattern so this step is target-agnostic: subset releases by
+      # deleting the target, not `enable_*: false` (a skipped `needs` job would skip this release job too). The release
+      # step guards `fail_on_unmatched_files: true`, so at least one `release-asset-*` must match; a repo that drops
+      # every file-producing target (e.g. a Docker-only repo, whose release carries only source zip + README + LICENSE)
+      # relaxes that guard.
       - name: Download release asset artifacts step
+        if: ${{ inputs.expect_release_assets }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: release-asset-${{ inputs.branch }}-*
           merge-multiple: true
           path: ./Publish
 
-      # Weekly re-runs may hit an already-released version; skip release-create when the tag exists (no-op republish).
+      # The weekly publisher re-runs even with no new commits, so the version may already be released. Skip the release
+      # step when a release for this tag already exists to avoid a no-op republish.
       - name: Check for existing release step
         id: release-exists
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.get-version.outputs.SemVer2 }}
         run: |
-          set -euo pipefail
+          set -Eeuo pipefail
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
@@ -139,8 +176,13 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # target_commitish pins the tag to the exact built commit (GitCommitId), not the moving branch ref.
-      # fail_on_unmatched_files catches a missing or misnamed PlexCleaner.7z.
+      # `target_commitish` must be set explicitly: otherwise GitHub's REST API tags the release on the default branch.
+      # Pin it to `GitCommitId` so the tag is on the exact built commit, consistent with the SemVer2 tag and artifacts.
+      # Skip when the release already exists, but always let a manual `workflow_dispatch` through to refresh it.
+      # Every release (any branch, any target) is a tag on the built commit plus the auto-attached source zip, README,
+      # and LICENSE; targets amend it by uploading `release-asset-*` files (binaries/packages) or pushing elsewhere
+      # (image/registry). `fail_on_unmatched_files: true` fails loudly if a promised `release-asset-*` is missing or
+      # misnamed; a no-file-target repo relaxes it (see download step).
       - name: Create GitHub release step
         if: ${{ steps.release-exists.outputs.exists == 'false' || github.event_name == 'workflow_dispatch' }}
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -149,8 +191,33 @@ jobs:
           tag_name: ${{ needs.get-version.outputs.SemVer2 }}
           target_commitish: ${{ needs.get-version.outputs.GitCommitId }}
           prerelease: ${{ inputs.branch != 'main' }}
-          fail_on_unmatched_files: true
+          fail_on_unmatched_files: ${{ inputs.expect_release_assets }}
           files: |
             LICENSE
             README.md
             ./Publish/*
+
+      # Surgical cleanup at the point of consumption: the release-asset-<branch>-* transfer artifacts now have durable
+      # copies on the release, so delete them by exact pattern to free the storage quota - scoped to this branch's
+      # assets, leaving diagnostics and any other artifacts. Gated to the same condition as the create step so it only
+      # deletes when a release was actually created/refreshed this run; on a skipped create (existing tag, no new
+      # commits) the fresh artifacts stay for the run, reaped by the retention-days: 1 backstop. Needs the caller to
+      # grant `actions: write` (publish-release's publish job does).
+      - name: Delete consumed release asset artifacts step
+        if: ${{ inputs.expect_release_assets && (steps.release-exists.outputs.exists == 'false' || github.event_name == 'workflow_dispatch') }}
+        # Best-effort: the release is already published, so a listing/delete hiccup must never red the job; the
+        # retention-days: 1 backstop reaps anything missed. Deletes every matching id (a rerun can upload duplicates).
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          if ! ids=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/${{ github.run_id }}/artifacts" --paginate \
+            --jq ".artifacts[] | select(.name | startswith(\"release-asset-${{ inputs.branch }}-\")) | .id"); then
+            echo "::warning::Could not list run artifacts; retention-days backstop will reap them."
+            ids=""
+          fi
+          for id in $ids; do
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$id" \
+              || echo "::warning::Failed to delete artifact $id; retention-days backstop will reap it."
+          done

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,6 +35,8 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
+      # The release job deletes the release-asset-* transfer artifacts once they are attached to the release.
+      actions: write
     with:
       # Pin the exact dispatch/schedule-time commit: a push landing mid-run must not be released unvalidated.
       ref: ${{ github.sha }}

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -86,7 +86,7 @@ Legibility rules. Necessary but not sufficient: a perfectly styled workflow can 
   a manual dispatch, or back-to-back dispatches against the shared Docker tags) and none is cancelled
   mid-release. The merge-bot also overrides it: it keys on the PR number with `cancel-in-progress: false`
   so each PR's events run to completion in order.
-- **Shells.** Every multi-line bash `run:` starts with `set -euo pipefail`.
+- **Shells.** Every multi-line bash `run:` starts with `set -Eeuo pipefail`.
 - **Conditionals.** Multi-line `if:` uses the folded scalar `if: >-`.
 - **Boolean inputs.** A boolean used by both `workflow_call` and `workflow_dispatch` is declared in both
   trigger blocks and compared against `true` and `'true'`.
@@ -94,7 +94,9 @@ Legibility rules. Necessary but not sufficient: a perfectly styled workflow can 
   job needs valid permissions. Grant least privilege; a callee's extra scope is granted by the caller.
 - **Allowlist `success` and `skipped` explicitly** across an optional dependency: use
   `(needs.X.result == 'success' || needs.X.result == 'skipped')`, not `!= 'failure'`.
-- **Line endings.** Workflow YAML follows [`.editorconfig`](./.editorconfig) (CRLF). Preserve on every edit.
+- **Line endings.** Workflow YAML follows [`.editorconfig`](./.editorconfig), which pins
+  `.github/workflows/*.{yml,yaml}` to **LF** (Dependabot and Actions rewrite these files with LF). Preserve on
+  every edit.
 
 ## 3. Architecture
 
@@ -132,12 +134,13 @@ NBGV classifies `publicReleaseRefSpec` from the `GITHUB_REF` environment variabl
 the **trigger ref** (one branch per run), `GITHUB_REF` already equals the branch being versioned - a schedule or
 `main` dispatch classifies as public (clean `X.Y.<height>`), a `develop` dispatch as prerelease
 (`X.Y.<height>-g<sha>`) - so no `GITHUB_REF` override is needed. (`IGNORE_GITHUB_REF` is only for matrix
-publishers that build a non-trigger branch.) The main-version backstop (D2.2) catches any misclassification.
+publishers that build a non-trigger branch.) The release-version gate (D2.2) catches any misclassification.
 
 ### Validate at entry
 
-A run that carries a cross-input invariant (e.g. `main` must not carry a prerelease suffix) asserts it once
-with `::error::` before any publish. Downstream jobs `needs:` it.
+A run that carries a cross-input invariant asserts it once with `::error::` before any build, not after one.
+The `validate-release` job is that gate: `main` must not carry a prerelease suffix, and every other branch
+must. Downstream jobs `needs:` it.
 
 ### Fast CI feedback, head-resolved
 
@@ -212,9 +215,9 @@ flowchart TD
 ```
 
 **Publish - `publish-release.yml` -> `build-release-task.yml`.** A weekly schedule (rebuilds `main`) or a
-dispatch on the started branch validates, versions once with NBGV, builds the per-RID executable 7z and the
-multi-arch Docker image, then cuts the GitHub release and pushes to Docker Hub (D2, D3, D4). Both output
-sinks are shown.
+dispatch on the started branch validates, versions once with NBGV, gates on the branch matching that version's
+classification, builds the per-RID executable 7z and the multi-arch Docker image, then cuts the GitHub release
+and pushes to Docker Hub (D2, D3, D4). Both output sinks are shown.
 
 ```mermaid
 flowchart TD
@@ -227,20 +230,20 @@ flowchart TD
         VAL["Validate job<br/>(validate-task.yml, branch ref)"] --> VG{"validate succeeded<br/>or skipped?"}:::gate
         VG -- "failed" --> VFAIL(["build + release skipped"]):::stop
         GV["Get version job<br/>NBGV @master, runs once<br/>SemVer2 + GitCommitId"]
+        GV --> VR{"Validate release job<br/>branch vs version classification<br/>(skipped on smoke)"}:::gate
+        VR -- "mismatch" --> VRX(["fail ::error::<br/>refuse to publish"]):::stop
         VG -- "ok" --> BE
-        VG -- "ok" --> BD
-        GV --> BE
-        GV --> BD
+        VR -- "ok" --> BE
         BE["Build executable job<br/>RID matrix: win-x64, linux-x64,<br/>linux-musl-x64, linux-arm, linux-arm64,<br/>osx-x64, osx-arm64 -> PlexCleaner.7z<br/>release-asset-&lt;branch&gt;-executable"]
-        BD["Build Docker job<br/>linux/amd64 + linux/arm64<br/>tags: latest|develop + :SemVer2"]
+        BE --> BD
+        BD["Build Docker job<br/>linux/amd64 + linux/arm64<br/>tags: latest|develop + :SemVer2<br/>skipped if any earlier build failed"]
         BD --> DH[("Docker Hub push<br/>ptr727/plexcleaner<br/>latest|develop + :SemVer2 (multi-arch)<br/>+ overview on main")]:::pub
         BE --> GR
         BD --> GR
-        GR{"github-release job<br/>main version clean?<br/>(strip +meta, no '-')"}:::gate
-        GR -- "main carries prerelease '-'" --> GRX(["fail ::error::<br/>refuse to publish"]):::stop
-        GR -- "ok" --> EX{"tag exists<br/>and not dispatch?"}:::gate
+        GR["github-release job"] --> EX{"tag exists<br/>and not dispatch?"}:::gate
         EX -- "exists, schedule" --> NOP(["skip release-create<br/>artifact reclaimed by backstop"]):::stop
         EX -- "create or dispatch refresh" --> REL[("GitHub release<br/>tag = SemVer2 at GitCommitId<br/>PlexCleaner.7z + README + LICENSE<br/>prerelease = branch != main")]:::pub
+        REL --> CLN(["delete release-asset-* artifacts<br/>best-effort, gated to the create"])
     end
     classDef trig fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
     classDef gate fill:#fef9c3,stroke:#ca8a04,color:#713f12
@@ -312,9 +315,11 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
 
 - **D2.1 Validate before publishing.** Output: a dedicated job/step asserts each cross-input invariant and
   fails fast with `::error::` before a publish; downstream jobs `needs:` it.
-- **D2.2 Main matches version classification.** Input: a real (non-smoke) publish run for `main`. Output: the
-  release fails loudly if `main` carries a prerelease suffix. It strips `+buildmetadata` before testing for
-  the prerelease `-`. Skipped on smoke. *Prevents a develop build published as the stable `latest`.*
+- **D2.2 Branch matches version classification.** Input: a real (non-smoke) publish run. Output: the dedicated
+  `validate-release` entry job fails loudly if `main` carries a prerelease suffix **or** a non-`main` branch
+  carries none. It strips `+buildmetadata` before testing for the prerelease `-` (only a core/prerelease `-`
+  counts), and it is skipped on smoke (a detached PR head always versions as prerelease). *Prevents a develop
+  build published as the stable `latest`, a develop leg classified public, and a build-metadata false positive.*
 
 ### D3 - Versioning and classification
 
@@ -371,6 +376,14 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
 - **D5.2 Transfer artifacts consumed by pattern.** The `github-release` job collects `release-asset-<branch>-*`
   by glob, so adding/removing a file-producing target needs no release-job edit.
 - **D5.3 Never blanket-delete.** Cleanup MUST NOT enumerate and delete the run's whole artifact set.
+- **D5.4 Delete at the point of consumption, gated to the consumer, best-effort.** The `github-release` job
+  deletes the `release-asset-<branch>-*` artifacts by exact pattern once they are attached to the release,
+  under the **same** condition as the release-create step - so a no-op re-run that skips the create also skips
+  the delete, and the `retention-days: 1` backstop reclaims those artifacts instead. The step is
+  `continue-on-error`, tolerates a failed listing, and deletes every matching id. It needs `actions: write`,
+  granted by the caller (`publish-release.yml`'s publish job). *Prevents transfer artifacts accumulating
+  against the storage quota, freshly built assets being deleted on a no-op re-run, and a cleanup hiccup
+  reddening a job whose publish succeeded.*
 
 ### D6 - Self-testing workflows
 
@@ -436,8 +449,10 @@ Read the workflow files plus `version.json` and assert the fact behind each appl
 - **D1:** CI runs on `push` with no paths filter; `validate` + `smoke-build` (both targets, `smoke: true`)
   run; every build `upload-artifact` is gated `!smoke`; `lint` runs CSharpier, `dotnet format style`,
   markdownlint, cspell on README/HISTORY, actionlint; the aggregator `needs:` both and blocks on non-success.
-- **D2:** the main release backstop checks the prerelease `-`, strips `+buildmetadata`, self-skips on smoke.
-- **D3:** `main` appears in the backstop and the `prerelease` expression; `publicReleaseRefSpec` is
+- **D2:** a dedicated `validate-release` job runs before the build jobs and they `needs:` it; it checks both
+  arms (main without a prerelease `-`, every other branch with one), strips `+buildmetadata`, self-skips on
+  smoke.
+- **D3:** `main` appears in the release-version gate and the `prerelease` expression; `publicReleaseRefSpec` is
   `^refs/heads/main$`.
 - **D4:** `publish-release` triggers are `schedule` + `workflow_dispatch` only (no `push`, no
   `PUBLISH_ON_MERGE`); the single `publish` job is guarded to `github.ref_name` in (`main`, `develop`) and
@@ -447,7 +462,8 @@ Read the workflow files plus `version.json` and assert the fact behind each appl
   release-create gated `exists == false || workflow_dispatch`; Docker buildcache is branch-scoped and
   write-gated on push; the Docker Hub overview push is gated to `main`.
 - **D5:** every upload sets `retention-days: 1`; the release job collects `release-asset-<branch>-*` by
-  pattern; no blanket artifact delete.
+  pattern and deletes those same artifacts by pattern under the release-create condition, `continue-on-error`;
+  the caller grants `actions: write`; no blanket artifact delete.
 - **D6:** CI is `push` on every branch; the aggregator context has exactly one producer; no
   `pull_request`-triggered fallback.
 - **D7:** the publisher group is ref-independent with `cancel-in-progress: false`; the merge-bot keys on PR
@@ -461,12 +477,12 @@ Read the workflow files plus `version.json` and assert the fact behind each appl
 
 | # | Input | Expected output | Exercises |
 | --- | --- | --- | --- |
-| S1 | push touching `PlexCleaner/**` | `validate` + `smoke-build` run; both targets compile/pack, **no push, no uploads, no release**; aggregator success; no dangling artifacts | D0.1, D1 |
+| S1 | push touching `PlexCleaner/**` | `validate` + `smoke-build` run; both targets compile/pack, **no push, no uploads, no release**; `validate-release` self-skips (smoke); aggregator success; no dangling artifacts | D0.1, D1, D2.2 |
 | S2 | push changing only docs | `validate` (lint checks markdown) + `smoke-build` run; nothing publishes | D1, D1.5 |
 | S3 | push changing only `.github/workflows/**` | `smoke-build` exercises the changed reusable workflow head-resolved; `lint` runs actionlint; aggregator success | D1.1, D6.1 |
 | S4 | weekly `schedule` | builds + publishes `main` only: stable release + refreshed `latest` (multi-arch) + `PlexCleaner.7z`; `target_commitish` = main's SHA; develop is not touched; no dangling artifacts | D4.1, D4.2, D4.4 |
 | S5 | `workflow_dispatch` from `develop` | builds + publishes `develop`: prerelease `X.Y.<height>-g<sha>` + `develop` image + `PlexCleaner.7z`; `github.ref` is develop, so NBGV classifies it non-public | D4.1, D4.2, D3.2 |
-| S6 | `workflow_dispatch` re-run, no new commits | release-create refreshed on dispatch (or skipped if the tag exists on schedule); Docker re-pushed (base refresh); no duplicate release | D4.5 |
+| S6 | `workflow_dispatch` re-run, no new commits | release-create refreshed on dispatch (or skipped if the tag exists on schedule); the `release-asset-*` delete is gated to the create, so a skipped create leaves them to the retention backstop; Docker re-pushed (base refresh); no duplicate release | D4.5, D5.4 |
 | S7 | `workflow_dispatch` from a feature branch | the `publish` job's `github.ref_name in (main, develop)` guard skips it -> no publish | D4.1 |
 | S8 | merged dependency bump (any) | `Directory.Packages.props` is not a shipped input and merges don't publish -> **no release**; ships in the next weekly run | D4.1, D8.2 |
 | S9 | merged GitHub-Actions bump | not a shipped input, merges don't publish -> **no release** | D4.1 |
@@ -474,6 +490,7 @@ Read the workflow files plus `version.json` and assert the fact behind each appl
 | S11 | `version.json` floor bump merged | merges don't publish -> no immediate release; the new floor ships in the next weekly publish | D3.3, D4.1 |
 | S12 | Dependabot semver-major bump (any ecosystem) | auto-merges on green like every other tier; the required checks are the gate | D8.2 |
 | S13 | `develop` -> `main` promotion (merge commit) | the merge itself does not publish; `main`'s accumulated changes ship in the next weekly run | D4.1, D8.1 |
+| S14 | branch and version classification disagree (NBGV mis-classifies) | `validate-release` **fails loud** with `::error::`; the build and publish jobs skip, so nothing is built or pushed | D2.2 |
 
 ### 5C. Live probe (where warranted, never publishing)
 


### PR DESCRIPTION
Phase 2, pass 1 of #880 - the whole-file `build-release-task.yml` re-vendor (item B1), now unblocked by the hub batch on `main`.

## What changed

**`validate-release` entry gate (new).** Vendored verbatim. It asserts branch/version consistency once, before the build jobs, and covers **both** arms - `main` must carry no prerelease `-`, every other branch must carry one. The old in-job "Verify public release version" step only checked the `main` arm, and only *after* the executable and Docker builds had already run. That step is gone; the gate replaces it.

**Canonical `github-release` job.** Taken as-is, which brings the D5.1 `release-asset-*` cleanup: the transfer artifacts are deleted by exact pattern at their point of consumption, gated to the same condition as the release-create step (so a no-op re-run that skips the create also skips the delete and lets the `retention-days: 1` backstop reclaim them), `continue-on-error`, deleting every matching id. `publish-release.yml` grants the `actions: write` that needs.

**Docker atomicity gate.** `build-docker` now guards `if: ${{ !failure() && !cancelled() }}` and needs the earlier jobs, so the image is never pushed on a partial run.

**`expect_release_assets` input added** (default `true`). The verbatim `github-release` job reads it in two places; without the declaration those expressions evaluate falsy, which would silently skip the asset download and relax `fail_on_unmatched_files` - a release published with no binaries.

## Deviations from the canonical, and why

Three, all forced by this repo's shape. Flagging them here and on #880 rather than burying them:

1. **`github-release`'s `needs` is pruned** to `[get-version, validate-release, build-executable, build-docker]`. This is the *only* line that differs from the canonical job (verified by normalized diff - EOL and action pins neutralized per the fidelity model). It is not optional: a `needs` entry naming `build-nugetlibrary` / `build-pypilibrary`, which this repo does not vendor, fails the workflow to load. Note this means the `verbatimJobs: ["github-release"]` check cannot pass for any subsetted repo.

2. **The Docker guard drops the `inputs.enable_docker` term.** This repo carries no `enable_*` inputs - CI has no `dorny/paths-filter` `changes` job by design (WORKFLOW.md D1: "CI runs on `push` with no paths filter"), so there is nothing to drive them. Referencing an undeclared input would evaluate falsy and silently never build the image. The audit contract does not require the inputs, so the guard adapts rather than the repo growing a knob no caller sets.

3. **`validate` stays in `build-docker`'s `needs`.** The hub's instruction gave `needs: [get-version, validate-release, build-executable]`, which omits this repo's local `validate` job (unit tests + lint, `!smoke`) - the canonical has no such job. Omitting it opens a hole: `failure()` only sees jobs in `needs`, and a failed `validate` *skips* rather than fails `build-executable`, so `!failure()` would be true and **the image would build and push after a failed test/lint run**. Keeping `validate` in `needs` closes it. Same reason `build-executable` gained an explicit `needs.validate-release.result == 'success'` clause: its `if` uses `!cancelled()`, which otherwise tolerates a failed need.

## Prose swept

`WORKFLOW.md`: D2.2 (both arms, dedicated job), new D5.4 (consume-then-delete contract), the publish mermaid diagram (the version gate moves out of `github-release`), the 5A D2/D3/D5 audit assertions, and scenario rows S1/S6 plus a new S14 (classification disagreement). The sweep also turned up two stale style claims, fixed here: the shell prologue is `set -Eeuo pipefail` (stale since the previous pass), and workflow YAML is pinned **LF**, not CRLF as claimed - `.editorconfig:42` has said LF the whole time.

## Observation, not a change

Making `build-docker` need `build-executable` serializes what used to run in parallel, including on smoke where Docker never pushes (`push: ${{ inputs.dockerhub && !inputs.smoke }}`), so PR feedback gets slower for no atomicity benefit on that path. The canonical accepts this tradeoff and so does this PR.

## Verification

`actionlint`, `markdownlint-cli2`, `editorconfig-checker`, `cspell`, and the husky pre-commit gate all clean. No C# changed. The `github-release` job was diffed against the canonical programmatically, not by eye. Line endings verified LF for the workflows, CRLF for `WORKFLOW.md`.