### PR TITLE
Fix metrics doc drift and counters.sh shell prologue

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,8 +79,8 @@ All external process execution uses [CliWrap](https://github.com/Tyrrrz/CliWrap)
 
 `Metrics.cs` owns a single `System.Diagnostics.Metrics.Meter` (`PlexCleaner.Process`) published for the whole process and read externally with `dotnet-counters` (no config flag, and instruments are inert until observed).
 
-- Hooks: `ProcessDriver.ProcessFiles` (the choke point every command and monitor cycle funnels through) drives the file/byte/in-flight instruments and the byte-weighted `progress.ratio`. `Process.ProcessFiles` records the per-`SidecarFile.StatesType` outcomes. `MediaTool` execution paths record `tool.duration`.
-- Progress is weighted by input bytes (summed once up front and credited at completion from the same map), not file count.
+- Hooks: `ProcessDriver.ProcessFiles` (the choke point every command and monitor cycle funnels through) drives the file/byte/in-flight instruments and the operation-weighted `progress.ratio`. `Process.ProcessFiles` records the per-`SidecarFile.StatesType` outcomes. `MediaTool` execution paths record `tool.duration`.
+- Progress is operation-weighted, not file count: each heavy full-file operation counts the file's size as work to do when it starts and as work done when it finishes, so the total grows as operations are discovered rather than being summed up front.
 - Run-scoped gauges (totals, in-flight, progress, ETA) reset per `ProcessFiles` call, while the counters stay cumulative for the process. All writers use `Interlocked`, so the parallel loop needs no lock, and observable-gauge callbacks only read. Tags are bounded (`state`, `tool`) - no filename tags.
 
 ### Sidecar File System

--- a/Docker/counters.sh
+++ b/Docker/counters.sh
@@ -6,7 +6,7 @@
 #   docker exec <container> counters             # live monitor of the PlexCleaner.Process meter
 #   docker exec <container> counters collect ... # any other dotnet-counters verb/args, passed through
 
-set -euo pipefail
+set -Eeuo pipefail
 
 export DOTNET_BUNDLE_EXTRACT_BASE_DIR="${DOTNET_BUNDLE_EXTRACT_BASE_DIR:-/tmp}"
 


### PR DESCRIPTION
Two review findings surfaced on the open `develop -> main` promotion (#884), both real and both on runtime-metrics content already merged to `develop`. Fixing them on `develop` so the promotion carries the fix rather than the defect.

## 1. ARCHITECTURE.md described the pre-operation-weighted model

The Runtime Metrics subsection still said progress is *"byte-weighted"* and *"weighted by input bytes (summed once up front and credited at completion)"* - the behavior before #869. The current model is **operation-weighted**: each heavy full-file operation counts the file's size as work when it starts and when it finishes, and the total **grows as operations are discovered** rather than being summed up front. That is what README, HISTORY, and `Metrics.cs` describe; ARCHITECTURE.md was the one place the old prose survived the #869 sweep. Both the `progress.ratio` label and the weighting bullet are corrected.

## 2. Docker/counters.sh used the short shell prologue

`set -euo pipefail` -> `set -Eeuo pipefail`, per the Workflow YAML Conventions shell rule (committed `.sh` scripts start with the full `-Eeuo` so a later `ERR` trap inherits).

## Verification

markdownlint-cli2, editorconfig-checker, shellcheck (counters.sh), cspell (README/HISTORY), husky pre-commit gate all clean. ARCHITECTURE.md CRLF, counters.sh LF preserved. No `byte-weighted` / `summed once up front` prose remains anywhere. No C# changed.