### PR TITLE
Re-vendor the carried hub files to the current canonical

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,9 +1,13 @@
 {
     "config": {
-        // Prose paragraphs and data-heavy tables/URLs are intentionally long.
-        // Reflowing at 80 cols hurts readability and churns diffs.
+        // Prose paragraphs and data-heavy tables or URLs are intentionally long.
+        // Reflowing at 80 columns hurts readability and churns diffs.
         "MD013": false,
-        // MD033 (inline HTML) stays enabled: HTML comments (reference-link dividers) pass it, and elements are flagged so native markdown wins.
+        // MD033 (inline HTML) stays enabled so native markdown wins.
+        // HTML comments, used as reference-link dividers, pass it.
+        // The details and summary elements are allowed for GitHub collapsibles, which have no markdown equivalent.
+        // Every other element still flags.
+        "MD033": { "allowed_elements": ["details", "summary"] },
         // Require fenced code blocks over the legacy 4-space-indented style.
         "MD046": { "style": "fenced" },
         // MD060 (table column style) is not enforced - allow both compact

--- a/repo-config/configure.sh
+++ b/repo-config/configure.sh
@@ -1,23 +1,26 @@
 #!/usr/bin/env bash
 # Configure or validate a repository against the committed fleet config in this directory, via the GitHub API.
 #
-#   repo-config/configure.sh apply [owner/repo] [release|operational]   # create-or-update settings + rulesets (writes)
-#   repo-config/configure.sh check [owner/repo] [release|operational]   # validate an existing repo, non-zero on drift (reads)
+#   Apply:  repo-config/configure.sh apply [owner/repo] [release|operational]   # create-or-update settings + rulesets (writes)
+#   Check:  repo-config/configure.sh check [owner/repo] [release|operational]   # validate an existing repo, non-zero on drift (reads)
 #
-# Both modes need admin on the repo (the rulesets endpoints require it). The command defaults to apply, the repo
-# to the current gh repo, and the model to the registry lookup (else inferred from the carried develop payload).
-# The model may be passed as the sole positional (e.g. `configure.sh check operational`), and the command may be
-# omitted for the apply default (`configure.sh owner/repo` still applies).
+# Both modes need admin on the repo, because the rulesets endpoints require it.
+# The command defaults to apply, the repo to the current gh repo, and the model to the registry lookup.
+# With no registry to consult, the model is inferred from the carried develop payload.
+# The model may be passed as the sole positional, as in `configure.sh check operational`.
+# The command may be omitted for the apply default, so `configure.sh owner/repo` still applies.
 #
-# apply: (1) settings.json via PATCH, plus has_discussions (public repos only) and default_branch (main, only if
-#           it exists). (2) Dependabot vulnerability alerts + automated security updates. (3) the branch rulesets -
-#           main.json (shared) and the model-specific develop ruleset (develop.json PR-gated, or operational/
-#           develop.json direct signed pushes), create-or-update by name. Idempotent.
-# check: the read-only inverse - every applied ruleset, setting, and security feature must match. The ruleset and
-#           settings assertions are driven by the committed payloads, so they stay repo-agnostic and survive the
-#           GitHub API normalizing a stored ruleset (rule presence + merge methods + required checks, not a byte
-#           diff). Secrets are per-repo (see spec/secrets.json) and not checkable from a standalone carry, so they
-#           are a manual-verify note.
+# The apply mode writes three groups, in order.
+# First settings.json via PATCH, plus has_discussions (public repos only) and default_branch (main, only when it exists).
+# Then the Dependabot vulnerability alerts and automated security updates.
+# Then the branch rulesets, main.json shared and the model-specific develop ruleset, create-or-update by name.
+# The develop ruleset is develop.json where the model is PR-gated, or operational/develop.json for direct signed pushes.
+# Applying the same configuration twice changes nothing, so the mode is idempotent.
+#
+# The check mode is the read-only inverse, where every applied ruleset, setting, and security feature must match.
+# The ruleset and settings assertions are driven by the committed payloads, so they stay repo-agnostic.
+# That also survives the GitHub API normalizing a stored ruleset, comparing rule presence, merge methods and required checks rather than a byte diff.
+# Secrets are per-repo (see spec/secrets.json) and not checkable from a standalone carry, so they are a manual-verify note.
 set -Eeuo pipefail
 
 # ----- Command + target + model -----
@@ -35,17 +38,19 @@ registry="$script_dir/../registry/repos.json"
 name="${repo##*/}"
 if [ -z "$model" ]; then
     if [ -f "$registry" ]; then
-        # Fail fast on a jq/parse error (malformed registry) instead of silently applying the release default to
-        # a repo whose lookup actually broke. A repo simply absent from the registry is not an error: the
-        # expression falls back through defaults.workflowModel to "release", so jq still exits 0 with a value.
+        # Fail fast on a jq or parse error (a malformed registry) rather than silently applying the release default.
+        # Silently defaulting would hide a lookup that actually broke.
+        # A repo simply absent from the registry is not an error.
+        # The expression falls back through defaults.workflowModel to "release", so jq still exits 0 with a value.
         if ! model="$(jq -r --arg n "$name" '(.repos[] | select(.name==$n) | .workflowModel) // .defaults.workflowModel // "release"' "$registry")"; then
             echo "Failed to read workflowModel from $registry (invalid JSON?). Pass the model explicitly (release|operational)." >&2
             exit 1
         fi
     else
-        # No registry to consult (a downstream carry): infer the model from which develop payload is carried - a
-        # carry holds exactly its own model's payload. Ambiguous layouts (both or neither, e.g. a partial copy)
-        # abort rather than guess - a wrong guess would apply or check the wrong develop ruleset.
+        # With no registry to consult (a downstream carry), infer the model from which develop payload is carried.
+        # A carry holds exactly its own model's payload.
+        # An ambiguous layout (both or neither, as in a partial copy) aborts rather than guesses.
+        # A wrong guess would apply or check the wrong develop ruleset.
         if [ -f "$script_dir/develop.json" ] && [ ! -f "$script_dir/operational/develop.json" ]; then
             model="release"
         elif [ -f "$script_dir/operational/develop.json" ] && [ ! -f "$script_dir/develop.json" ]; then
@@ -66,19 +71,21 @@ main_ruleset="$script_dir/main.json"
 settings_file="$script_dir/settings.json"
 
 # ----- Ruleset id lookup (shared by apply and check) -----
-ruleset_id() { # ruleset-name -> id of the first match (empty if none). Warns on duplicates. Aborts on an API error or at the per_page cap (the single-fetch lookup would be unreliable).
+# Map a ruleset name to the id of the first match, leaving it empty when nothing matches.
+# It warns on duplicates, and aborts on an API error or at the per_page cap, where a single-fetch lookup is unreliable.
+ruleset_id() {
     local out ids count
-    # per_page=100 returns every ruleset in one array (a repo has only a handful), so the response is a single
-    # JSON document - a paginated fetch would concatenate multiple arrays and break the single-array jq below.
-    # Let gh print its own error on stderr. Add a context line and return non-zero so the caller stops rather
-    # than treat an API failure as "not found".
+    # Requesting per_page=100 returns every ruleset in one array, since a repo carries only a handful.
+    # The response is then a single JSON document, where a paginated fetch would concatenate arrays and break the jq below.
+    # Let gh print its own error on stderr.
+    # Add a context line and return non-zero, so the caller stops rather than treat an API failure as "not found".
     if ! out="$(gh api "repos/$repo/rulesets?per_page=100")"; then
         echo "Failed to list rulesets for $repo (check auth and repo access)." >&2
         return 1
     fi
-    # Fail loud rather than silently narrow: a full page means the single-fetch assumption no longer holds, and
-    # a missed lookup would make apply create a duplicate ruleset by name. Abort so the caller stops (it treats a
-    # non-zero return as "stop", never as "not found").
+    # Fail loud rather than silently narrow, because a full page means the single-fetch assumption no longer holds.
+    # A missed lookup would make apply create a duplicate ruleset by name.
+    # Abort so the caller stops, since it treats a non-zero return as "stop" and never as "not found".
     if [ "$(jq 'length' <<<"$out")" -eq 100 ]; then
         echo "Failed for $repo: 100 rulesets returned (the per_page cap), so the single-fetch lookup is unreliable. Reduce rulesets or add pagination before applying." >&2
         return 1
@@ -86,9 +93,9 @@ ruleset_id() { # ruleset-name -> id of the first match (empty if none). Warns on
     # shellcheck disable=SC2016  # $n is a jq --arg variable, not a shell expansion
     ids="$(jq -r --arg n "$1" '.[] | select(.name==$n) | .id' <<<"$out")"
     if [ -z "$ids" ]; then return 0; fi
-    # Pre-existing drift can leave more than one ruleset with the same name. Use the first and warn so the
-    # duplicates are resolved rather than silently operating on the wrong one. grep -c and sed both read all
-    # input (no early pipe close), so neither SIGPIPEs jq under pipefail.
+    # Pre-existing drift can leave more than one ruleset with the same name.
+    # Use the first and warn, so the duplicates get resolved rather than silently operating on the wrong one.
+    # Both grep -c and sed read all their input with no early pipe close, so neither SIGPIPEs jq under pipefail.
     count="$(printf '%s\n' "$ids" | grep -c .)"
     if [ "$count" -gt 1 ]; then
         echo "Warning: $count rulesets named '$1' on $repo. Using the first (resolve the duplicates)." >&2
@@ -128,14 +135,15 @@ cmd_apply() {
         fi
     done
     echo "Applying configuration to $repo (model: $model)"
-    # The writes below silence stdout only (the success-response JSON is noise). They still fail loud -
-    # gh errors go to stderr and a failed write aborts the script (these writes run unguarded under `set -e`).
+    # The writes below silence stdout only, because the success-response JSON is noise.
+    # They still fail loud, since gh errors go to stderr and a failed write aborts the script.
+    # These writes run unguarded under `set -e`.
     # ----- General repository settings -----
-    # has_discussions: enabled on public repos only (fleet policy), never on private.
+    # Discussions are enabled on public repos only by fleet policy, and never on a private one.
     private="$(gh api "repos/$repo" --jq '.private')"
     disc=false; [ "$private" = "false" ] && disc=true
-    # default_branch main, but only point it at main when main exists - never set the default to a missing
-    # branch (e.g. a repo still on a rework branch).
+    # The default branch is main, but only point it there once main exists.
+    # Never set the default to a missing branch, as on a repo still living on a rework branch.
     if gh api "repos/$repo/branches/main" --jq '.name' >/dev/null 2>&1; then
         payload="$(jq --argjson d "$disc" '. + {has_discussions: $d, default_branch: "main"}' "$settings_file")"
     else
@@ -160,21 +168,25 @@ note() { printf '  %s\n' "$*"; }
 pass() { printf '  ok   %s\n' "$*"; }
 fail() { printf '  FAIL %s\n' "$*"; FAILED=1; }
 
-# assert MESSAGE TEST... - run the test command, pass on success, fail on non-zero (a proper if/else, not the
-# `A && B || C` footgun). Do not redirect the assert call's own stdout - that would swallow the pass/fail line;
-# a command that prints (jq) uses jq_has, which silences only itself.
+# Run a test command with `assert MESSAGE TEST...`, passing on success and failing on non-zero.
+# It is a proper if/else rather than the `A && B || C` footgun.
+# Do not redirect the assert call's own stdout, which would swallow the pass or fail line.
+# A command that prints, such as jq, goes through jq_has, which silences only itself.
 assert() { local msg="$1"; shift; if "$@"; then pass "$msg"; else fail "$msg"; fi; }
 
-# jq_has FILTER... - true iff the filter selects a truthy value. jq's output is discarded, not the caller's.
-# Reads JSON from stdin.
+# Test with `jq_has FILTER...`, which is true only when the filter selects a truthy value.
+# The jq output is discarded, not the caller's.
+# It reads its JSON from stdin.
 jq_has() { jq -e "$@" >/dev/null 2>&1; }
 
-# gh_ok ENDPOINT... - true iff the gh api call succeeds (2xx, including 204). Output and errors discarded, so it
-# is safe to pass to assert (e.g. vulnerability-alerts returns 204 enabled / 404 disabled).
+# Test with `gh_ok ENDPOINT...`, which is true only when the gh api call succeeds, a 204 included.
+# Output and errors are both discarded, so it is safe to pass to assert.
+# The vulnerability-alerts endpoint is the example, returning 204 when enabled and 404 when disabled.
 gh_ok() { gh api "$@" >/dev/null 2>&1; }
 
 check_ruleset() { # payload-file - the live ruleset must match the committed policy, driven by the payload
     local file="$1" rname id live t want got wantc gotc want_enf
+    if [ ! -e "$file" ]; then fail "ruleset payload $file missing"; return; fi
     rname="$(jq -r '.name // empty' "$file")"
     if [ -z "$rname" ]; then fail "ruleset payload $file has no name"; return; fi
     if ! id="$(ruleset_id "$rname")"; then fail "ruleset '$rname' - could not resolve id"; return; fi
@@ -187,13 +199,13 @@ check_ruleset() { # payload-file - the live ruleset must match the committed pol
         # shellcheck disable=SC2016  # $t is a jq --arg variable, not a shell expansion
         assert "'$rname' enforces rule '$t'" jq_has --arg t "$t" '.rules[] | select(.type==$t)' <<<"$live"
     done < <(jq -r '.rules[].type' "$file")
-    # pull_request: the live merge methods must match the payload (the develop=squash / main=merge policy).
+    # For pull_request, the live merge methods must match the payload, which is the develop=squash and main=merge policy.
     if jq_has '.rules[] | select(.type=="pull_request")' "$file"; then
         want="$(jq -c '[.rules[]|select(.type=="pull_request").parameters.allowed_merge_methods[]]|sort' "$file")"
         got="$(jq -c '[.rules[]|select(.type=="pull_request").parameters.allowed_merge_methods[]]|sort' <<<"$live")"
         assert "'$rname' merge methods = $want" test "$got" = "$want"
     fi
-    # required_status_checks: the live required contexts must match the payload.
+    # For required_status_checks, the live required contexts must match the payload.
     if jq_has '.rules[] | select(.type=="required_status_checks")' "$file"; then
         wantc="$(jq -c '[.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context]|sort' "$file")"
         gotc="$(jq -c '[.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context]|sort' <<<"$live")"
@@ -205,8 +217,8 @@ check_settings() {
     local live key want got private wantdisc
     if [ ! -e "$settings_file" ]; then fail "settings payload $settings_file missing"; return; fi
     if ! live="$(gh api "repos/$repo")"; then fail "could not read repository settings"; return; fi
-    # Static settings, driven from settings.json so the check never drifts from the file - add a key there and
-    # it is audited here automatically.
+    # Static settings are driven from settings.json, so the check never drifts from the file.
+    # Add a key there and it is audited here automatically.
     while IFS=$'\t' read -r key want; do
         # shellcheck disable=SC2016  # $k is a jq --arg variable, not a shell expansion
         got="$(jq -r --arg k "$key" '.[$k]' <<<"$live")"
@@ -223,9 +235,9 @@ check_settings() {
 
 check_security() {
     local sec
-    # vulnerability-alerts: 204 enabled / 404 disabled, so probe with gh_ok. automated-security-fixes returns
-    # a JSON body { enabled, paused }, captured under an explicit failure guard so a read error is a clean
-    # FAIL rather than a set -e abort.
+    # The vulnerability-alerts endpoint returns 204 when enabled and 404 when disabled, so probe it with gh_ok.
+    # The automated-security-fixes endpoint returns a JSON body of { enabled, paused }.
+    # That one is captured under an explicit failure guard, so a read error is a clean FAIL rather than a set -e abort.
     assert "Dependabot vulnerability alerts enabled" gh_ok "repos/$repo/vulnerability-alerts"
     if sec="$(gh api "repos/$repo/automated-security-fixes" 2>/dev/null)"; then
         assert "Dependabot automated security updates enabled" jq_has '.enabled == true' <<<"$sec"
@@ -240,8 +252,8 @@ cmd_check() {
     check_ruleset "$main_ruleset"
     check_settings
     check_security
-    # Secrets are per-repo (spec/secrets.json) and not readable by value. A standalone carry has no registry to
-    # derive the required set from, so they are verified by hand rather than asserted here.
+    # Secrets are per-repo (spec/secrets.json) and not readable by value.
+    # A standalone carry has no registry to derive the required set from, so they are verified by hand rather than asserted here.
     note "verify manually: the repo's required secrets (see spec/secrets.json) are present with valid values"
     if [ "$FAILED" -ne 0 ]; then echo "Configuration drift detected on $repo."; exit 1; fi
     echo "Configuration matches on $repo."


### PR DESCRIPTION
`.markdownlint-cli2.jsonc` and `repo-config/configure.sh` are carried `verbatim` from ptr727/ProjectTemplate, so a copy that differs is drift rather than a choice. The hub's regenerated fleet divergence report lists this repo for both.

**`.markdownlint-cli2.jsonc`** carries a behavior change: the canonical enables `MD033` with `details` and `summary` allowed. Verified rather than assumed: `markdownlint-cli2` over `**/*.md` reports **0 issues** here under the restored config.

**`repo-config/configure.sh`** advances to the current `apply` / `check` design. The older copy predates the payload-driven check mode.

Line endings preserved.

Not in this PR: this repo also carries `dotnet_analyzer_diagnostic.severity = suggestion` in `.editorconfig`. ptr727/ProjectTemplate#353 probed this repo at **0** hidden findings, so removal should be a no-op, but that probe is two weeks old and removal turns real analyzers back on, so it gets its own pull request with a build rather than riding along with a config copy.

Part of the fleet re-vendor sweep tracked in the hub's `TODO.md`.
