### PR TITLE
Measure whether the global Qodo settings repository is honored for a personal account

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,5 @@
+# Temporary, for the measurement on this pull request only. A repository's own file overrides the
+# global one, so an instruction placed here that reaches the review, when the same shape of
+# instruction in the global file did not, separates the delivery path from the key itself.
+[review_agent]
+issues_user_guidelines = "This pull request adds a file whose name begins with qodo-global-probe. Report that addition as an issue titled exactly PROBE-RULE-HIT, at any severity."

--- a/qodo-global-probe.md
+++ b/qodo-global-probe.md
@@ -16,5 +16,13 @@ The measurement reads two independent signals from the review this pull request 
 The two signals test different halves of the same claim and can disagree, which is why both are
 read.
 
-This pull request is closed unmerged once the review lands. Nothing here is intended to be kept,
+This pull request is closed unmerged once the review lands.
+
+## Control arm
+
+The first review carried no images, which is what the setting predicts, but Qodo changed its own
+review layout in the same two-day window, so that one observation cannot separate the setting being
+honored from a product change. The setting is now flipped to its default of `true` and this commit
+re-triggers the review. Images returning is explained only by the global configuration being read,
+because a product change cannot follow an edit to another repository. Nothing here is intended to be kept,
 and the measurement is recorded on <https://github.com/ptr727/ProjectTemplate/issues/1321>.

--- a/qodo-global-probe.md
+++ b/qodo-global-probe.md
@@ -1,0 +1,20 @@
+# Qodo Global Configuration Probe
+
+This file exists only to measure whether Qodo honors a global `pr-agent-settings` repository under
+a personal account rather than an organization. Qodo's documentation says the repository must live
+in an organization, and this account is a personal one, so the behavior is undocumented and has to
+be observed.
+
+The measurement reads two independent signals from the review this pull request draws.
+
+- <https://github.com/ptr727/pr-agent-settings> sets `use_images_and_animations = false`. Qodo
+  applies that itself rather than asking the model to comply, so the divider and severity images
+  disappearing from the review is the structural signal.
+- The same repository's `best_practices.md` reserves the `qodo-global-probe` file name prefix, so a
+  reported rule violation naming that rule is the second signal. This file carries that prefix.
+
+The two signals test different halves of the same claim and can disagree, which is why both are
+read.
+
+This pull request is closed unmerged once the review lands. Nothing here is intended to be kept,
+and the measurement is recorded on <https://github.com/ptr727/ProjectTemplate/issues/1321>.


### PR DESCRIPTION
## Temporary, and closed unmerged

This pull request is a measurement and is not intended to merge. It adds one Markdown file and
nothing else, and it is closed once the review lands.

## What it measures

Qodo reads a repository named `pr-agent-settings` under the account owner as the global
configuration for every repository under it. The documentation describes that as an
organization-level feature, and this account is a personal one, so whether it is honored here is
undocumented and has to be observed. That question is test 3 of
<https://github.com/ptr727/ProjectTemplate/issues/1321>.

`PlexCleaner` is the venue because it is the only repository in the fleet with a live Qodo
reviewer: the paid identity is paused across the account with a `qodo:billing-blocked` notice, and
the free open-source identity is star-gated, so it reviews here and not on the lower-starred
repositories.

## The two signals

<https://github.com/ptr727/pr-agent-settings> was created for this and holds both.

- `.pr_agent.toml` sets `use_images_and_animations = false`. Qodo applies that setting itself
  rather than asking the model to comply, so the divider and severity images disappearing from the
  review comment is a structural signal that needs no interpretation.
- `best_practices.md` reserves the `qodo-global-probe` file name prefix. The added file carries that
  prefix, so a reported rule violation naming the rule is the second signal.

The two test different halves of the same claim and can disagree, which is why both are read. A
negative result is only meaningful if Qodo's GitHub App can read the settings repository, since the
documentation says it skips the global configuration otherwise.

## After the reading

The branch and this pull request are deleted, and the settings repository is either kept, if the
fleet adopts it, or removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a control-arm section documenting review behavior with and without visual elements.
  * Clarified how product layout changes can affect interpretation of review observations.
  * Documented the configuration reset and follow-up review showing images returning.
  * Retained guidance for interpreting review signals and recording related observations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->